### PR TITLE
glossarytempgui_fix: adding jquery and javascript

### DIFF
--- a/Modules/LearningModule/Presentation/classes/class.ilLMPresentationGUI.php
+++ b/Modules/LearningModule/Presentation/classes/class.ilLMPresentationGUI.php
@@ -1646,6 +1646,14 @@ class ilLMPresentationGUI
 
         $term_gui = new ilGlossaryTermGUI($this->requested_obj_id);
 
+        //fau
+        //glossarytermgui_fix: adding jquery and javascript to display everything correct in presentation
+        //and slate
+        iljQueryUtil::initjQuery($this->tpl);
+        $this->tpl->addJavaScript('./Services/Accordion/js/accordion.js', true, 0);
+        $this->tpl->addJavaScript('./Services/COPage/js/ilCOPagePres.js', true, 0);
+        //fau
+
         // content style
         $this->setContentStyles();
 


### PR DESCRIPTION
GlossaryTerm hat jquery und noch 2 javascript-sources gefehlt um korrekt zu funktionieren.