### PR TITLE
coursePrint - open browser print windows on print course member list

### DIFF
--- a/Services/Membership/classes/class.ilAttendanceList.php
+++ b/Services/Membership/classes/class.ilAttendanceList.php
@@ -534,6 +534,9 @@ class ilAttendanceList
 
         $tpl = $DIC->ui()->mainTemplate();
         $tpl->setContent($this->getHTML());
+        // fau: coursePrint - open browser print windows on print course member list
+        $tpl->addOnLoadCode("il.Util.print();");
+        // fau.
         //$tpl->setVariable("CONTENT", $this->getHTML());
         //$tpl->setContent($this->getHTML());
     }


### PR DESCRIPTION
Beim drucken einer Kurs Mitgliederliste geht das Drucken Fenster nicht mehr auf wie in ILIAS 5.4
Der Testfall bei ILIAS sagt lediglich:
„ILIAS öffnet eine Druckansicht der Liste der Mitglieder.“

Es handelt sich nicht um einen Bug, sondern das Öffnen des Druck-Fensters wurde nach einer Umstellung wohl nicht mehr implementiert. 

Mit dieser Anpassung geht das Drucken Fenster wie zuvor wieder auf. Bitte prüfen und falls gewünscht übernehmen. Eintrag ins Anpassungsdokument erfolgt anschließend. 

