### PR TITLE
dcl_fix_missing_fields: activated comments not crash edit-entry-view any more

### DIFF
--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldModel.php
@@ -560,7 +560,10 @@ class ilDclBaseFieldModel
      */
     public function getViewSetting(int $tableview_id) : ilDclTableViewFieldSetting
     {
-        return ilDclTableViewFieldSetting::where(array('field' => $this->getId(), 'tableview_id' => $tableview_id))->first();
+        //fau
+        //dcl_fix_missing_fields: old function did not handle missing field-elements
+        return ilDclTableViewFieldSetting::getInstance($tableview_id, $this->getId());
+        //fau
     }
 
 

--- a/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldModel.php
+++ b/Modules/DataCollection/classes/Fields/Base/class.ilDclBaseFieldModel.php
@@ -560,10 +560,9 @@ class ilDclBaseFieldModel
      */
     public function getViewSetting(int $tableview_id) : ilDclTableViewFieldSetting
     {
-        //fau
-        //dcl_fix_missing_fields: old function did not handle missing field-elements
+        // fau: dclFixMissingFields: old function did not handle when comment is missing (or field is missing)
         return ilDclTableViewFieldSetting::getInstance($tableview_id, $this->getId());
-        //fau
+        // fau.
     }
 
 


### PR DESCRIPTION
datensammlung: 
aktivierte kommentar-funktion führt zu crash bei eintrag editieren.
where funktion von activedirectory gibt null zurück, weil kein feld vorhanden.
mit getinstance wird zumindest ein setting-eintrag angelegt. 