### PR TITLE
dcl_fix_missing_fieldtype: fix crash when fieldtype was not set

### DIFF
--- a/Modules/DataCollection/classes/Fields/Selection/class.ilDclSelectionFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Selection/class.ilDclSelectionFieldRepresentation.php
@@ -88,7 +88,10 @@ abstract class ilDclSelectionFieldRepresentation extends ilDclBaseFieldRepresent
                 }
                 $input->setOptions($array);
                 break;
-            case ilDclSelectionFieldModel::SELECTION_TYPE_COMBOBOX:
+            //fau
+            //dcl_fix_missing_fieldtype: if no type is set-> use combobox
+            default:
+            //fau
                 $input = new ilSelectInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
                 $array = array();
                 foreach ($options as $opt) {

--- a/Modules/DataCollection/classes/Fields/Selection/class.ilDclSelectionFieldRepresentation.php
+++ b/Modules/DataCollection/classes/Fields/Selection/class.ilDclSelectionFieldRepresentation.php
@@ -88,10 +88,9 @@ abstract class ilDclSelectionFieldRepresentation extends ilDclBaseFieldRepresent
                 }
                 $input->setOptions($array);
                 break;
-            //fau
-            //dcl_fix_missing_fieldtype: if no type is set-> use combobox
+            // fau: dclFixMissingFieldType: if no type is set -> use combobox
             default:
-            //fau
+            // fau.
                 $input = new ilSelectInputGUI($this->getField()->getTitle(), 'field_' . $this->getField()->getId());
                 $array = array();
                 foreach ($options as $opt) {


### PR DESCRIPTION
Nicht ausgefüllte Feldtypen in Datensammlungen, führen nicht mehr zu Exception