### PR TITLE
Fix for problem with tags in code output of assignment

### DIFF
--- a/Modules/Exercise/classes/class.ilExAssignmentGUI.php
+++ b/Modules/Exercise/classes/class.ilExAssignmentGUI.php
@@ -575,7 +575,7 @@ class ilExAssignmentGUI
                 $a_info->addProperty(
                     $lng->txt("exc_comment"),
                     // fau: exFeedbackHtml - allow secure html output
-                    nl2br(ilUtil::secureString($lpcomment))
+                    nl2br(ilUtil::secureString(htmlentities($lpcomment)))
                     // fau.
                 );
 


### PR DESCRIPTION
htmlentities is here the best solution, to cancel out written html-tags.
i have still let the ilUtil::secureString in, cause it catches some other important stuff