### PR TITLE
Exmatrikulations-Email erweitern

### DIFF
--- a/Customizing/patches/remind_exmatriculation.html
+++ b/Customizing/patches/remind_exmatriculation.html
@@ -1,3 +1,5 @@
++++FAU-Scientia-Studierende sind hiervon nicht betroffen. In diesem Fall können Sie diese E-Mail ignorieren.+++
+
 {salutation}
 
 Sie erhalten diese automatische E-Mail, da in StudOn für Ihr IdM-Konto zum kommenden Semester noch keine Studiengansdaten vorliegen. Falls Sie zum {date} exmatrikuliert werden, können Sie sich ab diesem Datum nicht mehr per Single-Sign-On bei StudOn einloggen.


### PR DESCRIPTION
Die FAU-Scientia Studierenden hatten nach Erhalt der Exmatrikulierenden-Information bei der Verantwortlichen Sturm gelaufen.
Deswegen müssen wir die E-Mail erweitern und so die Scientia-Studierenden beruhigen.
Minimale Änderung an der Vorlage-HTML-Datei