### PR TITLE
Fix cron schedule types

### DIFF
--- a/Services/FAU/classes/class.ilFairAutoFillCron.php
+++ b/Services/FAU/classes/class.ilFairAutoFillCron.php
@@ -2,6 +2,8 @@
 
 /* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
+
 include_once "Services/Cron/classes/class.ilCronJob.php";
 
 /**
@@ -30,7 +32,7 @@ class ilFairAutoFillCron extends ilCronJob
     
     public function getDefaultScheduleType(): ILIAS\Cron\Schedule\CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_MINUTES;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES;
     }
     
     public function getDefaultScheduleValue(): ?int

--- a/Services/FAU/classes/class.ilSyncToCampoCron.php
+++ b/Services/FAU/classes/class.ilSyncToCampoCron.php
@@ -1,5 +1,6 @@
 <?php
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * fau: syncToCampo - new class for campo data update cron job.
@@ -27,7 +28,7 @@ class ilSyncToCampoCron extends ilCronJob
     
     public function getDefaultScheduleType(): ILIAS\Cron\Schedule\CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_MINUTES;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES;
     }
     
     public function getDefaultScheduleValue(): ?int

--- a/Services/FAU/classes/class.ilSyncWithCampoCron.php
+++ b/Services/FAU/classes/class.ilSyncWithCampoCron.php
@@ -1,5 +1,6 @@
 <?php
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * fau: syncWithCampo - new class for campo data update cron job.
@@ -27,7 +28,7 @@ class ilSyncWithCampoCron extends ilCronJob
     
     public function getDefaultScheduleType(): ILIAS\Cron\Schedule\CronJobScheduleType
     {
-        return ILIAS\Cron\Schedule\CronJobScheduleType::SCHEDULE_TYPE_IN_HOURS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES;
     }
     
     public function getDefaultScheduleValue(): ?int

--- a/Services/FAU/classes/class.ilSyncWithIdmCron.php
+++ b/Services/FAU/classes/class.ilSyncWithIdmCron.php
@@ -1,5 +1,6 @@
 <?php
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * fau: syncWithIdm - new class for idm data update cron job.
@@ -27,7 +28,7 @@ class ilSyncWithIdmCron extends ilCronJob
     
     public function getDefaultScheduleType(): ILIAS\Cron\Schedule\CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_DAILY;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES;
     }
     
     public function getDefaultScheduleValue(): ?int

--- a/Services/FAU/classes/class.ilSyncWithOrgCron.php
+++ b/Services/FAU/classes/class.ilSyncWithOrgCron.php
@@ -1,5 +1,6 @@
 <?php
 
+use ILIAS\Cron\Schedule\CronJobScheduleType;
 
 /**
  * fau: syncWithOrg - new class for fau.org data update cron job.
@@ -27,7 +28,7 @@ class ilSyncWithOrgCron extends ilCronJob
     
     public function getDefaultScheduleType(): ILIAS\Cron\Schedule\CronJobScheduleType
     {
-        return self::SCHEDULE_TYPE_IN_HOURS;
+        return CronJobScheduleType::SCHEDULE_TYPE_IN_MINUTES;
     }
     
     public function getDefaultScheduleValue(): ?int


### PR DESCRIPTION
This fixes setup errors like the following

[ERROR] Undefined constant ilSyncToCampoCron::SCHEDULE_TYPE_IN_MINUTES   