### PR TITLE
add fau:customSettings and fau:idmPass to version 9

### DIFF
--- a/Customizing/apply_patches.php
+++ b/Customizing/apply_patches.php
@@ -136,3 +136,10 @@ $p->login();
 //$p->applyPatch('ilPermissionPatches7.initPluginsCopyPermissions');
 //$p->applyPatch('ilPermissionPatches7.initCourseRefLearningProgress');
 //$p->applyPatch('ilPermissionPatches7.initInteractiveVideoLearningProgress');
+
+/******************
+ * Testing Patches
+ *****************/
+
+//$p->applyPatch('ilTestingPatches.testIdmPass', ['login' => 'idmpass.crypt', 'password'=> 'homer', 'encoding' => 'idmcrypt']);
+//$p->applyPatch('ilTestingPatches.testIdmPass', ['login' => 'idmpass.ssha', 'password'=> 'homer', 'encoding' => 'idmssha']);

--- a/Customizing/patches/class.ilTestingPatches.php
+++ b/Customizing/patches/class.ilTestingPatches.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * fau: customPatches - patches for testing functionalities
+ */
+class ilTestingPatches
+{
+    /** @var ilDBInterface  */
+    protected $db;
+
+    public function __construct() {
+        global $DIC;
+        $this->db = $DIC->database();
+    }
+
+
+    /**
+     * fau: idmPass - test password encoder (new password will be saved for the account)
+     */
+    public function testIdmPass($params = array('login' => '', 'password'=> '', 'encoding' => 'idmssha'))
+    {
+        // needed for user object update
+        if (!defined("ILIAS_HTTP_PATH")) {
+            define("ILIAS_HTTP_PATH", "http://localhost");
+        }
+
+        $login = (string) $params['login'];
+        $password = (string) $params['password'];
+        $encoding = (string) $params['encoding'];
+
+        $user_id = ilObjUser::_lookupId($login);
+        if (empty($user_id)) {
+            echo "User $login not found.\n";
+            return;
+        }
+        $user_obj = new ilObjUser($user_id);
+
+        $manager = ilUserPasswordManager::getInstance();
+        $manager->setEncoderName($encoding);
+
+        echo "Encode password '$password' for User '$login' with encoding '$encoding'. \n";
+        $manager->encodePassword($user_obj, $password);
+
+        echo "Verify password '$password' for User '$login' with encoding '$encoding'. \n";
+        $valid = $manager->verifyPassword($user_obj, $password);
+
+        echo $valid ? "valid\n" : "not valid\n";
+
+        if ($valid) {
+            echo "Store password '$password' for User '$login' with encoding '$encoding'. \n";
+        }
+
+        $user_obj->update();
+    }
+}
+

--- a/Services/Context/classes/class.ilContext.php
+++ b/Services/Context/classes/class.ilContext.php
@@ -64,6 +64,9 @@ class ilContext
     public const CONTEXT_SHIBBOLETH = ilContextShibboleth::class;
     public const CONTEXT_LTI_PROVIDER = ilContextLTIProvider::class;
     public const CONTEXT_SAML = ilContextSaml::class;
+    // fau: customPatches - add context for patches
+    const CONTEXT_PATCH = ilContextPatch::class;
+    // fau.
 
     /**
      * Init context by type

--- a/Services/Context/classes/class.ilContextPatch.php
+++ b/Services/Context/classes/class.ilContextPatch.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * fau: customPatches - new context for patches.
+ * Allow HTTP and HTML and Templates, which may be needed for deleting objects
+ */
+
+include_once "Services/Context/interfaces/interface.ilContextTemplate.php";
+
+/**
+ * Service context for patches
+ *
+ * @ingroup ServicesContext
+ */
+class ilContextPatch implements ilContextTemplate
+{
+    /**
+     * Are redirects supported?
+     *
+     * @return bool
+     */
+    public static function supportsRedirects(): bool
+    {
+        return false;
+    }
+    
+    /**
+     * Based on user authentication?
+     *
+     * @return bool
+     */
+    public static function hasUser(): bool
+    {
+        return true;
+    }
+    
+    /**
+     * Uses HTTP aka browser
+     *
+     * @return bool
+     */
+    public static function usesHTTP(): bool
+    {
+        return false;
+    }
+    
+    /**
+     * Has HTML output
+     *
+     * @return bool
+     */
+    public static function hasHTML(): bool
+    {
+        return true;
+    }
+    
+    /**
+     * Uses template engine
+     *
+     * @return bool
+     */
+    public static function usesTemplate(): bool
+    {
+        return true;
+    }
+    
+    /**
+     * Init client
+     *
+     * @return bool
+     */
+    public static function initClient(): bool
+    {
+        return true;
+    }
+    
+    /**
+     * Try authentication
+     *
+     * @return bool
+     */
+    public static function doAuthentication(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Check if persistent session handling is supported
+     * @return boolean
+     */
+    public static function supportsPersistentSessions(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Supports push messages
+     *
+     * @return bool
+     */
+    public static function supportsPushMessages(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function isSessionMainContext(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function modifyHttpPath(string $httpPath) : string
+    {
+        return $httpPath;
+    }
+}

--- a/Services/Password/classes/encoders/class.ilIdmCryptPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilIdmCryptPasswordEncoder.php
@@ -1,0 +1,60 @@
+<?php
+// fau: idmPass - new class ilIdmCryptPasswordEncoder.
+
+require_once 'Services/Password/classes/class.ilBasePasswordEncoder.php';
+
+/**
+ * Class ilIdmCryptPasswordEncoder
+ * @package ServicesPassword
+ */
+class ilIdmCryptPasswordEncoder extends ilBasePasswordEncoder
+{
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws ilPasswordException
+     */
+    public function encodePassword(string $raw, string $salt) : string
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            require_once 'Services/Password/exceptions/class.ilPasswordException.php';
+            throw new ilPasswordException('Invalid password.');
+        }
+
+        return "{CRYPT}" . password_hash($raw, PASSWORD_BCRYPT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordValid(string $encoded, string $raw, string $salt) : bool
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            return false;
+        }
+
+        // check encoding type
+        $prefix = substr($encoded, 0, 7);
+        if ($prefix != '{CRYPT}') {
+            return false;
+        }
+
+        $encoded = substr($encoded, 7);
+
+        return password_verify($raw, $encoded);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName() : string
+    {
+        return 'idmcrypt';
+    }
+}

--- a/Services/Password/classes/encoders/class.ilIdmSshaPasswordEncoder.php
+++ b/Services/Password/classes/encoders/class.ilIdmSshaPasswordEncoder.php
@@ -1,0 +1,67 @@
+<?php
+// fau: idmPass - new class ilIdmSshaPasswordEncoder.
+
+require_once 'Services/Password/classes/class.ilBasePasswordEncoder.php';
+
+/**
+ * Class ilIdmSshaPasswordEncoder
+ * @package ServicesPassword
+ */
+class ilIdmSshaPasswordEncoder extends ilBasePasswordEncoder
+{
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws ilPasswordException
+     */
+    public function encodePassword(string $raw, string $salt) : string
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            throw new ilPasswordException('Invalid password.');
+        }
+
+        if (empty($salt)) {
+            $salt = pack("CCCC", mt_rand(), mt_rand(), mt_rand(), mt_rand());
+        }
+
+        return "{SSHA}" . base64_encode(sha1($raw . $salt, true) . $salt);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordValid(string $encoded, string $raw, string $salt) : bool
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            return false;
+        }
+
+        // check encoding type
+        $prefix = substr($encoded, 0, 6);
+        if ($prefix != '{SSHA}') {
+            return false;
+        }
+
+        // extract the salt
+        if (empty($salt)) {
+            $content = base64_decode(substr($encoded, 6));
+            $salt = substr($content, 20);
+        }
+
+        return $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName() : string
+    {
+        return 'idmssha';
+    }
+}

--- a/Services/User/classes/class.ilUserPasswordEncoderFactory.php
+++ b/Services/User/classes/class.ilUserPasswordEncoderFactory.php
@@ -55,6 +55,10 @@ class ilUserPasswordEncoderFactory
             new ilBcryptPhpPasswordEncoder($config),
             new ilBcryptPasswordEncoder($config),
             new ilMd5PasswordEncoder(),
+            // fau: idmPass - add idm encoders
+            new ilIdmSshaPasswordEncoder($config),
+            new ilIdmCryptPasswordEncoder($config)
+            // fau.
         ];
     }
 


### PR DESCRIPTION
Der PR enthält zwei Patches:

customSettings - add patch context and patch for testing 
Damit funktioniert das Skript apply_patches.php wieder. Ich werde es verwenden, um Testfunktionen für die übertragenen Anpassungen zu schreiben.

idmPass - add password encoders and testing encoders patch
Passwortkodierungen für alte auf lokal umgestellte IDM-Passwörter. Die Kodierungen können mit der Patch-Funktion "ilTestingPatches.testIdmPass" für Beispielnutzer gesetzt und anschließend beim lokalen Login getestet werden.