### PR TITLE
add fau: loginFailed to version 9

### DIFF
--- a/Services/Authentication/classes/class.ilAuthStatus.php
+++ b/Services/Authentication/classes/class.ilAuthStatus.php
@@ -110,10 +110,15 @@ class ilAuthStatus
      */
     public function getTranslatedReason(): string
     {
+        // fau: loginFailed - add a help text to the failure message
         if ($this->translated_reason !== '') {
-            return $this->translated_reason;
+            $message = $this->translated_reason;
+        } else {
+            $message = $this->lng->txt($this->getReason());
         }
-        return $this->lng->txt($this->getReason());
+
+        return $message . $this->lng->txt('err_wrong_login_assist');
+        // fau.
     }
 
 


### PR DESCRIPTION
Die Meldung bei einem fehlgeschlagenen Login entspricht der von ILIAS, wird aber um einen Hilfetext ergänzt.