### PR TITLE
add fau: loginFallback to version 9

### DIFF
--- a/Services/Authentication/classes/Provider/class.ilAuthProviderDatabase.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderDatabase.php
@@ -44,6 +44,23 @@ class ilAuthProviderDatabase extends ilAuthProvider
                 return false;
             }
 
+            // fau: loginFallback - try for login with matriculation as password
+            // this setting must be restricted to installations where only admins have access
+            // this must be done before the check if local auth is enabled for an account
+            if (ilCust::get('local_auth_matriculation') && $this->getCredentials()->getPassword() != '') {
+                // take the user that is already found
+                if ($user instanceof ilObjUser) {
+                    $this->getLogger()->debug('Trying to authenticate with matriculation as password for: ' . $user->getLogin());
+                    if ($user->getMatriculation() == $this->getCredentials()->getPassword()) {
+                        $this->getLogger()->debug('Successfully authenticated user: ' . $user->getLogin());
+                        $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
+                        $status->setAuthenticatedUserId($user->getId());
+                        return true;
+                    }
+                }
+            }
+            // fau.
+
             if (!ilAuthUtils::isLocalPasswordEnabledForAuthMode($user->getAuthMode(true))) {
                 $this->getLogger()->debug('DB authentication failed: current user auth mode does not allow local validation.');
                 $this->getLogger()->debug('User auth mode: ' . $user->getAuthMode(true));
@@ -60,6 +77,31 @@ class ilAuthProviderDatabase extends ilAuthProvider
                 return true;
             }
         }
+
+        // fau: loginFallback - check password from a remote account with same login
+        if (ilCust::get('local_auth_remote')) {
+            // take the user that is already found
+            if ($user instanceof ilObjUser) {
+                $this->getLogger()->debug('Trying to authenticate with remote account: ' . $user->getLogin());
+                $db = ilRemoteAuthDB::getInstance();
+                if (!isset($db)) {
+                    $this->getLogger()->debug('remote db not connected');
+                }
+                else {
+                    $remoteUser = $db->getRemoteUser($user->getLogin());
+                    if (!isset($remoteUser)) {
+                        $this->getLogger()->debug('remote user not found');
+                    }
+                    elseif (ilUserPasswordManager::getInstance()->verifyPassword($remoteUser, $this->getCredentials()->getPassword())) {
+                        $this->getLogger()->debug('Successfully authenticated remote user: ' . $user->getLogin());
+                        $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
+                        $status->setAuthenticatedUserId($user->getId());
+                        return true;
+                    }
+                }
+            }
+        }
+        // fau.
 
         $this->handleAuthenticationFail($status, 'err_wrong_login');
 

--- a/Services/Authentication/classes/Provider/class.ilRemoteAuthDB.php
+++ b/Services/Authentication/classes/Provider/class.ilRemoteAuthDB.php
@@ -1,0 +1,71 @@
+<?php
+// Copyright (c) 2021 Institut fuer Lern-Innovation, Friedrich-Alexander-Universitaet Erlangen-Nuernberg, GPLv3, see LICENSE
+
+/**
+* fau: loginFallback - wrapper for a connection to a remote ILIAS database.
+*
+* This class extends the main ILIAS database wrapper ilDB.
+*/
+class ilRemoteAuthDB extends ilDBPdoMySQLInnoDB
+{
+
+	/** @var  self $instance */
+	private static $instance;
+
+
+	/**
+	 * Get the database connection instance
+	 * @return self
+     * @throws Exception
+	 */
+	public static function getInstance()
+	{
+	    global $DIC;
+
+        // read the client settings if available
+        $settings = [];
+        if (isset($DIC) && $DIC->offsetExists('ilClientIniFile'))
+        {
+            /** @var ilIniFile $ilClientIniFile */
+            $ilClientIniFile = $DIC['ilClientIniFile'];
+            $settings = $ilClientIniFile->readGroup('db_remote');
+        }
+
+        if (!isset(self::$instance))
+        {
+            $instance = new self;
+            $instance->setDBHost($settings['host'] ?? '');
+            $instance->setDBPort($settings['port'] ?? 3306);
+            $instance->setDBUser($settings['user'] ?? '');
+            $instance->setDBPassword($settings['pass'] ?? '');
+            $instance->setDBName($settings['name'] ?? '');
+            if (!$instance->connect(true))
+            {
+                return null;
+            }
+            self::$instance = $instance;
+        }
+
+        return self::$instance;
+	}
+
+    /**
+     * Get a user account with remote data
+     * @param string $login
+     * @return ilObjUser|null
+     */
+	public function getRemoteUser($login)
+    {
+        $query = "SELECT * from usr_data WHERE login = " . $this->quote($login, 'text');
+        $result = $this->query($query);
+        if ($data = $this->fetchAssoc($result)) {
+            $data["passwd_type"] = ilObjUser::PASSWD_CRYPTED;
+            $user = new ilObjUser();
+            $user->assignData($data);
+            // prevent user object from misinterpretation as local user and from manipulation
+            $user->setId(- $user->getId());
+            return $user;
+        }
+        return null;
+    }
+}

--- a/Services/User/classes/class.ilObjUser.php
+++ b/Services/User/classes/class.ilObjUser.php
@@ -2807,12 +2807,14 @@ class ilObjUser extends ilObject
         }
 
         // For compatibility, check for login (no ext_account entry given)
+        // fau: loginFallback - allow local login with different external account (e.g. vhb user)
         $res = $db->queryF(
             "SELECT login FROM usr_data " .
-            "WHERE login = %s AND auth_mode = %s AND (ext_account IS NULL OR ext_account = '') ",
+            "WHERE login = %s AND auth_mode = %s ",
             ["text", "text"],
             [$a_account, $a_auth]
         );
+        // fau.
         if ($usr = $db->fetchAssoc($res)) {
             return $usr['login'];
         }


### PR DESCRIPTION
Beim lokalen Login sind neben dem ILIAS-Nutzernamen und Passwort auch andere Eingaben möglich, deren Unterstützung in customize.ini.php konfiguriert wird:
// die Matrikelnummer kann verwendet werden
local_auth_matriculation = "0" 

// Login und Passwort werden in der Datenbank einer anderen Plattform gesucht
local_auth_remote = "0"


Die Datenbank der anderen Plattform ist in der client.ini.php konfiguriert:
[db_remote]
type = "innodb"
host = ""
name = ""
user = ""
pass = ""
