### PR TITLE
add fau: loginForm to version 9

### DIFF
--- a/Customizing/global/lang/ilias_de.lang.local
+++ b/Customizing/global/lang/ilias_de.lang.local
@@ -242,6 +242,9 @@ common#:#rpl_overview#:#Übersicht der Anmeldestarts
 common#:#rpl_overview_desc#:#Diese Tabelle zeigt die vorgesehenen Anmeldestarts für Gruppen und Kurse mit beschränkter Teilnehmerzahl. Pro Zeitraum sind alle Plätze summiert, für die eine Anmeldung startet. Hohe Werte geben einen Hinweis auf erhöhte Zugriffe, allerdings spielen auch andere Faktoren, z.B. die Beliebtheit von Kursen eine Rolle. Bitte wählen Sie für eigene Anmeldestarts möglichst einen freien Zeitraum. In den ersten beiden Wochen des Vorlesungszeitraums ist generell mit hoher Systemlast zu rechnen.
 common#:#rpl_previous_week#:#Vorherige Woche
 common#:#rpl_warning#:#Die Registrierung startet zeitgleich mit anderen für über %s Plätze. Dadurch ist mit erhöhter Systemlast zu rechnen. Bitte wählen Sie, wenn möglich, einen anderen Zeitpunkt.
+common#:#saml_log_in#:#Anmelden###fau: loginForm
+common#:#saml_login_form_info_txt#:#Verwenden Sie als Mitglied der FAU Ihre IdM-Kennung » <strong><a href="https://www.studon.fau.de/studon/goto.php?target=cat_166816">Hilfe</a></strong>###fau: loginForm
+common#:#saml_login_form_txt#:#Bei StudOn über Single Sign-On anmelden###fau: loginForm
 common#:#score#:#Punkte
 common#:#select_all_page_only#:#Alle auf dieser Seite auswählen. Lassen Sie mehr Zeilen pro Seite anzeigen, um alle auswählen zu können!
 common#:#shib_data_missing#:#Ihr Single Sign-On hat funktioniert, aber es fehlen Daten (Vor- oder Nachname), um ein Benutzerkonto in StudOn anlegen zu können. Bitte wenden Sie sich an den IDM-Support <a href="mailto:idm@fau.de">idm@fau.de</a>, um das Problem zu beheben und nennen Sie dabei Ihre Benutzerkennung und die fehlenden Daten.

--- a/Customizing/global/lang/ilias_en.lang.local
+++ b/Customizing/global/lang/ilias_en.lang.local
@@ -191,7 +191,7 @@ common#:#label_remark#:#References
 common#:#lang_refresh_confirm_info#:#ILIAS found changed language variables. Refreshing a language will read the standard language file and probably a custom language file to the database. This will not affect your changes.###fau: keepAllLocalChanges
 common#:#links_password_coded#:#password-code
 common#:#local_login_to_ilias#:#Local Login to StudOn###fau: loginForm
-common#:#local_login_to_ilias_addition#:#Use this login if you got a local account from StudOn###fau.
+common#:#local_login_to_ilias_addition#:#Use this login if you got a local account from StudOn###fau: loginForm
 common#:#local_login_to_ilias_registered#:#Login###fau: regCodes
 common#:#login_required_for_object#:#Bitte melden Sie sich an.
 common#:#mail_folder_tools#:#You will find your Mail-Folder under „Tools“
@@ -243,6 +243,9 @@ common#:#rpl_overview#:#Overview of Registration starts
 common#:#rpl_overview_desc#:#This tables shows the registration starts for courses and groups with a limited number of places. Each time slot show the sum of places for which the registration starts. High values may indicate a high system load, but uther factors like the popularity of courses may be relevant, too. Please try to use a free slot for your own registration start. The first two weeks of the lectures period have a high load generally.
 common#:#rpl_previous_week#:#Previous Week
 common#:#rpl_warning#:#The registration starts at the same time with others for over %s places. This may cause high system load. Please choose a different time, if possible.
+common#:#saml_log_in#:#Login###fau: loginForm
+common#:#saml_login_form_info_txt#:#As a member of FAU, you can log in to StudOn with your IdM-ID » <strong><a href="https://www.studon.fau.de/studon/goto.php?target=cat_166816">Help</a></strong>###fau: loginForm
+common#:#saml_login_form_txt#:#Login with Single Sign-On###fau: loginForm
 common#:#score#:#Points
 common#:#select_all_page_only#:#Select all on this page. Show more rows per page to select all!
 common#:#shib_data_missing#:#Your Single Sign-On did work, some data is missing (firstname or lastname) to create a user account for StudOn. Please contact<a href="idm@fau.de">idm@fau.de</a>, to solve the problem and tell your user identification and the missing data.

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -513,7 +513,11 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
                 ),
         ];
 
-        $sections = [$field_factory->section($fields, $this->lng->txt('login_to_ilias'))];
+        // fau: loginForm - use specific language variables for local login
+        $sections = [$field_factory->section($fields,
+            $this->lng->txt('local_login_to_ilias'))->withByline($this->lng->txt('local_login_to_ilias_addition'))
+        ];
+        // fau.
 
         return $this->ui_factory->input()
                                 ->container()

--- a/Services/Saml/templates/default/tpl.login_form_saml.html
+++ b/Services/Saml/templates/default/tpl.login_form_saml.html
@@ -1,16 +1,17 @@
-<form method="post" name="samllogin" class="form-horizontal preventDoubleSubmission">
-	<div class="form-horizontal">
-		<div class="ilFormHeader">
-			<h3 class="ilHeader">{LOGIN_TO_ILIAS_VIA_SAML}</h3>
-		</div>
-		<div class="form-group row">
-			<div class="col-sm-12">{TXT_SAML_LOGIN_INFO_TXT}</div>
-		</div>
-		<div class="ilFormFooter row clearfix">
-			<div class="col-sm-6">&nbsp;</div>
-			<div class="col-sm-6 ilFormCmds">
-				<a href="{SAML_SCRIPT_URL}" class="submit btn btn-default">{TXT_LOGIN}</a>
+<!-- fau: loginForm - adapt to the standard login form, e.h. same header level. -->
+<form method="post" name="samllogin" class="il-standard-form form-horizontal" role ="form">
+	<div class="il-standard-form-header clearfix">&nbsp;</div>
+	<div class="il-section-input">
+		<div class="il-section-input-header">
+			<h2>{TXT_SAML_LOGIN_TXT}</h2>
+			<div class="il-section-input-header-byline">
+				{TXT_SAML_LOGIN_INFO_TXT}
 			</div>
+		</div>
+	</div>
+	<div class="il-standard-form-footer clearfix">
+		<div class="il-standard-form-cmd">
+			<a class="submit btn btn-default" href="{SAML_SCRIPT_URL}">{TXT_LOGIN}</a>
 		</div>
 	</div>
 </form>


### PR DESCRIPTION
Die HTML-Struktur des Formulars für das SAML-Login (Single Sign-On) wurde dem lokalen Login-Formular angeglichen (gleiche Überschriften-Ebene). Das Formular für das lokale Login hat wie das Formular zum Single Sign-On eine Beschreibungszeile unter der Überschrift.

Hinweis zur Überarbeitung:

- In den SAML-Einstellungen sollte sie Anzeige im Login-Formular aktiviert sein. 
- Im Seiteneditor auf der Login-Seite den Content des Akkordion-Fachs zum SSO durch das Loginseiten-Element "SAML-Login" ersetzen
- Die lokalen Sprachvariablen neu einlesen
- Der Link zu SSO-Hilfe steht nun in der Sprachvariable "saml_login_form_info_txt"