### PR TITLE
Studon9 databay pwchangeform

### DIFF
--- a/Customizing/global/lang/ilias_de.lang.local
+++ b/Customizing/global/lang/ilias_de.lang.local
@@ -968,7 +968,7 @@ user#:#browser_agent#:#Browser-Familie
 user#:#browser_desc#:#Browser-Beschreibung
 user#:#browser_platform#:#Betriebssystem
 user#:#browser_version#:#Browser-Version
-user#:#confirm_password_assistance#:#Möchten Sie einen Link zur Änderung Ihres Passworts an %s schicken lassen? Sie werden anschließend ausgeloggt.
+user#:#confirm_password_assistance#:#Möchten Sie einen Link zur Änderung Ihres Passworts an %s schicken lassen? Sie müssen sich vor den Aufruf des Links ausloggen.
 user#:#current_password_info#:#<strong>Hinweis für vhb-Studierende:</strong> Ihr StudOn-Kennwort entspricht nicht dem des vhb-Portals! Wenn Sie Ihr StudOn-Kennwort noch nicht kennen, wählen Sie oben die Funktion "Passwort vergessen?" Sie erhalten dann außerhalb StudOn per E-Mail einen Link mit dem Sie Ihr neues Passwort setzen können. Falls Sie die E-Mail nicht finden, sehen Sie bitte auch im Spam-Ordner Ihres E-Mail-Postfaches nach.
 user#:#idle_ext_account#:#Inaktive IDM-Kennung
 user#:#idle_ext_account_info#:#IDM-Kennung, mit welcher das Benutzerkonto nicht mehr verbunden ist (z.B. nach Exmatrikulation) oder noch nicht verbunden ist (z.B. bei vorab registrierten Studierenden). Sobald ein Single-Sign-On mit dieser Kennung erfolgt, wird der Account mit ihr verbunden und auf "Shibboleth" umgestellt.

--- a/Customizing/global/lang/ilias_en.lang.local
+++ b/Customizing/global/lang/ilias_en.lang.local
@@ -963,7 +963,7 @@ user#:#browser_agent#:#Browser Family
 user#:#browser_desc#:#Broeser Description
 user#:#browser_platform#:#Platform
 user#:#browser_version#:#Browser Version
-user#:#confirm_password_assistance#:#Send a password assistance link to an %s? You will be logged out.
+user#:#confirm_password_assistance#:#Send a password assistance link to an %s? You must be logged out when using this link.
 user#:#current_password_info#:#<strong>Note for vhb students:</strong> Your StudOn password is not the same as the vhb portal! If you do not know your StudOn password yet, select the function "Forgot your password?" above. You will then receive outside StudOn by e-mail a link with which you can set your new password. If you do not find the e-mail, please also check the spam folder of your e-mail inbox.
 user#:#idle_ext_account#:#Inactive IDM Account
 user#:#idle_ext_account_info#:#IDM account to which the user account is no longer connected (e.g. after exmatriculation) or is not yet connected (e.g. for pre-registered students). As soon as a single sign-on is made with this ID, the account is connected to it and switched to "Shibboleth".

--- a/Services/Init/classes/class.ilPasswordAssistanceGUI.php
+++ b/Services/Init/classes/class.ilPasswordAssistanceGUI.php
@@ -375,7 +375,9 @@ class ilPasswordAssistanceGUI implements ilCtrlSecurityInterface
      * client_id
      * key
      */
-    private function sendPasswordAssistanceMail(ilObjUser $userObj): void
+    // fau: pwChangeForm - make sendPasswordAssistanceMail public
+    public function sendPasswordAssistanceMail(ilObjUser $userObj): void
+    // fau.
     {
         global $DIC;
 

--- a/Services/User/classes/Settings/class.ilPersonalSettingsGUI.php
+++ b/Services/User/classes/Settings/class.ilPersonalSettingsGUI.php
@@ -215,6 +215,18 @@ class ilPersonalSettingsGUI
 
         if ($this->allowPasswordChange()) {
             $pw_info_set = false;
+
+            // fau: pwChangeForm - show username, add button for password assistance
+            $login = new ilNonEditableValueGUI($this->lng->txt('login'), 'login');
+            $login->setValue($this->user->getLogin());
+            $this->form->addItem($login);
+
+            $button = ilLinkButton::getInstance();
+            $button->setCaption('forgot_password', true);
+            $button->setUrl($this->ctrl->getLinkTarget($this, 'confirmPasswordAssistance'));
+            $this->toolbar->addButtonInstance($button);
+            // fau.
+
             if ($this->user->getAuthMode(true) == ilAuthUtils::AUTH_LOCAL) {
                 // current password
                 $cpass = new ilPasswordInputGUI($this->lng->txt('current_password'), 'current_password');
@@ -225,6 +237,10 @@ class ilPersonalSettingsGUI
                 // only if a password exists.
                 if ($this->user->getPasswd()) {
                     $cpass->setRequired(true);
+                    // fau: pwChangeForm - and info for "password assistance" and enable later info for password requirements
+                    $cpass->setInfo($this->lng->txt('current_password_info'));
+                    $pw_info_set = false;
+                    // fau.
                 }
                 $this->form->addItem($cpass);
             }
@@ -260,6 +276,60 @@ class ilPersonalSettingsGUI
             $this->form->setFormAction($this->ctrl->getFormAction($this));
         }
     }
+
+    // fau: pwChangeForm - new function confirmPasswordAssistance()
+    /**
+     * Confirm the sending of a password assistance mail
+     */
+    protected function confirmPasswordAssistance()
+    {
+        // normally we should not end up here
+        if (!$this->allowPasswordChange()) {
+            $this->ctrl->redirect($this, "showPersonalData");
+            return;
+        }
+
+        $this->initSubTabs("showPersonalData");
+        $this->tabs->activateTab("password");
+        $this->setHeader();
+
+        $gui = new ilConfirmationGUI();
+        $gui->setFormAction($this->ctrl->getFormAction($this));
+        $gui->setHeaderText(sprintf($this->lng->txt('confirm_password_assistance'), $this->user->getEmail()));
+        $gui->addHiddenItem('username',  $this->user->getLogin());
+        $gui->addHiddenItem('email',  $this->user->getEmail());
+
+        $gui->setConfirm($this->lng->txt('ok'), 'sendPasswordAssistanceMail');
+        $gui->setCancel($this->lng->txt('cancel'), 'showPassword');
+
+
+        $this->tpl->setContent($gui->getHTML());
+        $this->tpl->printToStdOut();
+    }
+    // fau.
+
+    // fau: pwChangeForm - new function sendPasswordAssistanceMail()
+    /**
+     * Send a mail for password assistance
+     */
+    protected function sendPasswordAssistanceMail()
+    {
+        // normally we should not end up here
+        if (!$this->allowPasswordChange()) {
+            $this->ctrl->redirect($this, "showPersonalData");
+            return;
+        }
+
+        $this->lng->loadLanguageModule('pwassist');
+        $gui = new ilPasswordAssistanceGUI();
+        $gui->sendPasswordAssistanceMail($this->user);
+
+        $this->tpl->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_SUCCESS,
+            sprintf($this->lng->txt('pwassist_mail_sent'), $this->user->getEmail()));
+        $this->ctrl->redirect($this, 'showPassword');
+    }
+    // fau.
+
 
     /**
      * Check, whether password change is allowed for user


### PR DESCRIPTION
Im Formular zum Ändern des Passworts wird der Benutzername angezeigt. Bei der Eingabe des bisherigen Passwortes erscheint ein Hinweis, dass man die Passwort-Unterstützung verwenden kann.
Über dem Formular gibt es einen Button „Passwort vergessen?“, mit dem man die Passwort-Unterstützung aufrufen kann. Nach einer Bestätigungs-Abfrage wird der Passwort-Ändern-Link an die eigene E-Mail-Adresse gesendet.

Hinweis zur Überarbeitung:
Nach Senden des Links zur Passwort-Unterstützung wird man nicht mehr automatisch ausgeloggt. Das ist eine Änderung im ILIAS-Kern zwischen 7 und 9. Ich habe die Sprachvariablen bei der Bestätigungs-Abfrage so angepasst, dass man sich selbst ausloggen muss, bevor man den Link zur Passwort-Unterstützung aufruft.