### PR TITLE
add fau: samlAuth, samlChange, requestLog to version 9

### DIFF
--- a/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
+++ b/Services/Authentication/classes/Frontend/class.ilAuthFrontend.php
@@ -194,6 +194,12 @@ class ilAuthFrontend
                 case ilAuthStatus::STATUS_AUTHENTICATED:
                     return $this->handleAuthenticationSuccess($provider);
 
+                // fau: samlChange - handle change request
+                case ilAuthStatus::STATUS_SSO_CHANGE_REQUIRED:
+                    $this->logger->notice("Account migration required.");
+                    return false;
+                // fau.
+
                 case ilAuthStatus::STATUS_ACCOUNT_MIGRATION_REQUIRED:
                     $this->logger->notice("Account migration required.");
                     if ($provider instanceof ilAuthProviderAccountMigrationInterface) {

--- a/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
+++ b/Services/Authentication/classes/Provider/class.ilAuthProviderFactory.php
@@ -95,7 +95,9 @@ class ilAuthProviderFactory
 
             case ilAuthUtils::AUTH_SAML:
                 $this->logger->debug('Using apache authentication.');
-                return new ilAuthProviderSaml($credentials, ilSamlIdp::getIdpIdByAuthMode($a_authmode));
+// fau: samlAuth - use StudOn Auth provider
+                return new ilAuthProviderSamlStudOn($credentials, ilSamlIdp::getIdpIdByAuthMode($a_authmode));
+// fau.
 
             case ilAuthUtils::AUTH_OPENID_CONNECT:
                 $this->logger->debug('Using openid connect authentication.');

--- a/Services/Authentication/classes/class.ilAuthStatus.php
+++ b/Services/Authentication/classes/class.ilAuthStatus.php
@@ -36,6 +36,10 @@ class ilAuthStatus
     public const STATUS_ACCOUNT_MIGRATION_REQUIRED = 4;
     public const STATUS_CODE_ACTIVATION_REQUIRED = 5;
 
+    // fau: samlChange - new auth status code
+    const STATUS_SSO_CHANGE_REQUIRED = 550;
+    // fau.
+
     private int $status = self::STATUS_UNDEFINED;
     private string $reason = '';
     private string $translated_reason = '';
@@ -134,4 +138,36 @@ class ilAuthStatus
     {
         return $this->auth_user_id;
     }
+
+    // fau: samlChange - new getters and setters in auth status
+    public function getSsoChangeIdentity(): string
+    {
+        return $this->sso_change_identity;
+    }
+
+    public function setSsoChangeIdentity(string $sso_change_identity): void
+    {
+        $this->sso_change_identity = $sso_change_identity;
+    }
+
+    public function getSsoChangeLogins(): array
+    {
+        return $this->sso_change_logins;
+    }
+
+    public function setSsoChangeLogins(array $sso_change_logins): void
+    {
+        $this->sso_change_logins = $sso_change_logins;
+    }
+
+    public function getSsoChangeSelectedLogin(): string
+    {
+        return $this->sso_change_selected_login;
+    }
+
+    public function setSsoChangeSelectedLogin(string $sso_change_selected_login): void
+    {
+        $this->sso_change_selected_login = $sso_change_selected_login;
+    }
+    // fau.
 }

--- a/Services/Authentication/classes/class.ilAuthStatus.php
+++ b/Services/Authentication/classes/class.ilAuthStatus.php
@@ -37,7 +37,7 @@ class ilAuthStatus
     public const STATUS_CODE_ACTIVATION_REQUIRED = 5;
 
     // fau: samlChange - new auth status code
-    const STATUS_SSO_CHANGE_REQUIRED = 550;
+    public const STATUS_SSO_CHANGE_REQUIRED = 550;
     // fau.
 
     private int $status = self::STATUS_UNDEFINED;
@@ -45,7 +45,11 @@ class ilAuthStatus
     private string $translated_reason = '';
     private int $auth_user_id = 0;
 
-
+    // fau: samlChange - new class variables in auth status
+    private $sso_change_identity = '';
+    private $sso_change_logins = [];
+    private $sso_change_selected_login = '';
+    // fau.
 
     /**
      * Constructor

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -280,6 +280,15 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         $page_editor_html = $this->showLegalDocumentsLinks($page_editor_html);
         $page_editor_html = $this->purgePlaceholders($page_editor_html);
 
+        // fau: samlAuth - provide a login URL with return target
+        $return = '';
+        if ($this->http->wrapper()->query()->has('target')) {
+            $return = '?returnTo=' . urlencode(ilUtil::stripSlashes(
+                    $this->http->wrapper()->query()->retrieve('target', $this->refinery->kindlyTo()->string())));
+        }
+        $page_editor_html = str_replace('SAML_LOGIN_URL',  './saml.php' . $return, $page_editor_html);
+        // fau.
+
         // check expired session and send message
         if ($this->authSession->isExpired() || $this->http->wrapper()->query()->has('session_expired')) {
             $this->mainTemplate->setOnScreenMessage('failure', $this->lng->txt('auth_err_expired'));
@@ -296,6 +305,18 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
                 $this->lng->txt($message_key)
             );
         }
+
+        // fau: samlAuth - show a message if a reason is provided in the login link
+        if ($this->http->wrapper()->query()->has('reason')) {
+            $reason = ilUtil::secureString(
+                $this->http->wrapper()->query()->retrieve('reason', $this->refinery->kindlyTo()->string())
+            );
+            $tpl->setOnScreenMessage(
+                ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt($reason) . $this->lng->txt('err_wrong_login_assist'));
+        }
+        // fau.
+
         if ($page_editor_html !== '') {
             $tpl->setVariable('LPE', $page_editor_html);
         }
@@ -1311,12 +1332,15 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
                 'used_external_auth_mode' => $used_external_auth_mode,
             ]
         );
-        if ($used_external_auth_mode && (int) $this->user->getAuthMode(true) === ilAuthUtils::AUTH_SAML) {
+
+        // fau: samlAuth - do SAML logout when auth mode is Shibboleth
+        if ($used_external_auth_mode && (int) $this->user->getAuthMode(true) === ilAuthUtils::AUTH_SHIBBOLETH) {
             $this->logger->info('Redirecting user to SAML logout script');
             $this->ctrl->redirectToURL(
                 'saml.php?action=logout&logout_url=' . urlencode(ilUtil::_getHttpPath() . '/login.php')
             );
         }
+        // fau.
 
         // reset cookie
         ilUtil::setCookie("ilClientId", "");

--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -311,7 +311,7 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             $reason = ilUtil::secureString(
                 $this->http->wrapper()->query()->retrieve('reason', $this->refinery->kindlyTo()->string())
             );
-            $tpl->setOnScreenMessage(
+            $this->mainTemplate->setOnScreenMessage(
                 ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
                 $this->lng->txt($reason) . $this->lng->txt('err_wrong_login_assist'));
         }
@@ -1090,6 +1090,103 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             $page_editor_html
         );
     }
+
+    // fau: samlChange - new functions showChangeToSso and changeToSso
+    public function showChangeToSso()
+    {
+        $identity = (string) ilSession::get('sso_change_identity');
+        $logins = (array) ilSession::get('sso_change_logins');
+
+        $this->mainTemplate->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_INFO,
+            $this->lng->txt('sso_change_explanation'));
+
+        $form = new ilPropertyFormGUI();
+        $form->setTitle($this->lng->txt('sso_change_select_account'));
+        $form->setFormAction($this->ctrl->getFormAction($this, 'changeToSso'));
+
+        $radio = new ilRadioGroupInputGUI($this->lng->txt('sso_change_selecte_login'), 'selected_login');
+        foreach ($logins as $login) {
+            $option = new ilRadioOption($login, $login);
+            $password = new ilPasswordInputGUI($this->lng->txt('password'), "password[$login]");
+            $password->setRequired(true);
+            $password->setRetype(false);
+            $option->addSubItem($password);
+            $radio->addOption($option);
+        }
+        $option = new ilRadioOption($this->lng->txt('sso_change_none'), 'sso_change_none');
+        $radio->addOption($option);
+        $form->addItem($radio);
+
+        $form->addCommandButton('changeToSso', $this->lng->txt('save'));
+        $form->addCommandButton('showLoginPage', $this->lng->txt('cancel'));
+
+        $this->mainTemplate->setContent($form->getHTML());
+        $this->mainTemplate->printToStdout();
+    }
+
+    public function changeToSso() : void
+    {
+        $identity = (string) ilSession::get('sso_change_identity');
+        $logins = (array) ilSession::get('sso_change_logins');
+
+        if (empty($identity) || empty($logins)) {
+            $this->showLoginPage();
+            return;
+        }
+
+        $post = $this->httpRequest->getParsedBody();
+
+        if (empty($post['selected_login'])) {
+            $this->mainTemplate->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt('sso_change_please_select'));
+            $this->showChangeToSso();
+            return;
+        }
+
+        $login = $post['selected_login'];
+
+        // new account should be created
+        if ($login == 'sso_change_none') {
+            ilSession::set('sso_change_selected_login', $this->dic->fau()->user()->generateLogin($identity));
+            $this->doSamlAuthentication();
+            return;
+        }
+
+        if (!in_array($login, $logins)) {
+            $this->mainTemplate->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt('sso_change_please_select'));
+            $this->showChangeToSso();
+            return;
+        }
+
+        $user_id = ilObjUser::getUserIdByLogin($login);
+        if (empty($user_id)) {
+            $this->mainTemplate->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt('sso_change_please_select'));
+            $this->showChangeToSso();
+            return;
+        }
+        $user = new ilObjUser($user_id);
+
+        $password = $post['password'][$login] ?? [];
+
+        if (empty($password)) {
+            $this->mainTemplate->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt('sso_change_password_required'));
+            $this->showChangeToSso();
+        }
+
+        else if (!ilUserPasswordManager::getInstance()->verifyPassword($user, $password)) {
+            $this->mainTemplate->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt('sso_change_password_is_wrong'));
+            $this->showChangeToSso();
+        }
+        else {
+            ilSession::set('sso_change_selected_login', $post['selected_login']);
+            $this->doSamlAuthentication();
+        }
+    }
+    // fau.
 
     private function buildAccountMigrationForm(): ILIAS\UI\Component\Input\Container\Form\Form
     {
@@ -1907,6 +2004,11 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         }
 
         $status = ilAuthStatus::getInstance();
+        // fau: samlChange - get the selected login
+        if (!empty($selected_login = ilSession::get('sso_change_selected_login'))) {
+            $status->setSsoChangeSelectedLogin($selected_login);
+        }
+        // fau.
 
         $frontend_factory = new ilAuthFrontendFactory();
         $frontend_factory->setContext(ilAuthFrontendFactory::CONTEXT_STANDARD_FORM);
@@ -1921,9 +2023,22 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
         switch ($status->getStatus()) {
             case ilAuthStatus::STATUS_AUTHENTICATED:
                 $this->logger->debug('Authentication successful; Redirecting to starting page.');
+                // fau: samlChange - clear session variables
+                ilSession::clear('sso_change_identity');
+                ilSession::clear('sso_change_logins');
+                ilSession::clear('sso_change_selected_login');
+                //fau.
                 ilInitialisation::redirectToStartingPage($target ?? '');
 
-                // no break
+            // fau: samlChange - handle change request
+            case ilAuthStatus::STATUS_SSO_CHANGE_REQUIRED:
+                ilSession::set('sso_change_identity', $status->getSsoChangeIdentity());
+                ilSession::set('sso_change_logins', $status->getSsoChangeLogins());
+
+                $this->ctrl->redirect($this, 'showChangeToSso');
+            // fau.
+
+            // no break
             case ilAuthStatus::STATUS_ACCOUNT_MIGRATION_REQUIRED:
                 $this->ctrl->redirect($this, 'showAccountMigration');
 

--- a/Services/Saml/classes/class.ilAuthProviderSaml.php
+++ b/Services/Saml/classes/class.ilAuthProviderSaml.php
@@ -32,12 +32,14 @@ class ilAuthProviderSaml extends ilAuthProvider implements ilAuthProviderAccount
 
     private ilSamlIdp $idp;
     private readonly ilLanguage $lng;
-    // fau: samlAuth - maje attributes available for child class
+    // fau: samlAuth - make attributes available for child class
     /** @var array<string, mixed> */
     protected array $attributes = [];
     // fau.
     private string $return_to = '';
-    private string $uid = '';
+    // fau: samlAuth - make uid available for child class
+    protected string $uid = '';
+    // fau.
     private bool $force_new_account = false;
     private string $migration_account = '';
 

--- a/Services/Saml/classes/class.ilAuthProviderSaml.php
+++ b/Services/Saml/classes/class.ilAuthProviderSaml.php
@@ -32,8 +32,10 @@ class ilAuthProviderSaml extends ilAuthProvider implements ilAuthProviderAccount
 
     private ilSamlIdp $idp;
     private readonly ilLanguage $lng;
+    // fau: samlAuth - maje attributes available for child class
     /** @var array<string, mixed> */
-    private array $attributes = [];
+    protected array $attributes = [];
+    // fau.
     private string $return_to = '';
     private string $uid = '';
     private bool $force_new_account = false;

--- a/Services/Saml/classes/class.ilAuthProviderSamlStudOn.php
+++ b/Services/Saml/classes/class.ilAuthProviderSamlStudOn.php
@@ -26,11 +26,11 @@ class ilAuthProviderSamlStudOn extends ilAuthProviderSaml
 
         try {
             // get the uid attribute
-            $this->uid = $this->attributes['urn:mace:dir:attribute-def:uid'][0];
+            $this->uid = $this->attributes['urn:mace:dir:attribute-def:uid'][0] ?? '';
 
             // needed since ILIAS 5.4.10
             if (empty($this->uid)) {
-                $this->uid = $this->attributes['urn:oid:0.9.2342.19200300.100.1.1'][0];
+                $this->uid = $this->attributes['urn:oid:0.9.2342.19200300.100.1.1'][0] ?? '';
             }
 
 
@@ -57,7 +57,7 @@ class ilAuthProviderSamlStudOn extends ilAuthProviderSaml
                 $this->handleAuthenticationFail($status, 'auth_shib_not_configured');
                 return false;
             }
-            
+
 
             $login = $this->findLogin();
             // take an already selected login fon the SSO change
@@ -155,7 +155,7 @@ class ilAuthProviderSamlStudOn extends ilAuthProviderSaml
 
         // set basic account data
         $userObj->setLogin($login);
-        $userObj->setPasswd(null);
+        $userObj->setPasswd('');
         $userObj->setLanguage($DIC->language()->getLangKey());
         $userObj->setAuthMode('shibboleth');
         $userObj->setExternalAccount($this->identity->getPkPersistentId());
@@ -241,7 +241,7 @@ class ilAuthProviderSamlStudOn extends ilAuthProviderSaml
             $log_accounts = explode(',', $log_accounts);
             foreach ($log_accounts as $log_account) {
                 if ($this->uid == trim($log_account)) {
-                    require_once "include/inc.debug.php";
+                    require_once "include/inc.log_request.php";
                     log_request();
                     log_server();
                 }

--- a/Services/Saml/classes/class.ilAuthProviderSamlStudOn.php
+++ b/Services/Saml/classes/class.ilAuthProviderSamlStudOn.php
@@ -1,0 +1,264 @@
+<?php
+/* Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+use FAU\Staging\Data\Identity;
+
+/**
+ * fau: samlAuth - new class for saml authentication in studon
+ * fau: samlChange - initiate and handle change requests
+ */
+class ilAuthProviderSamlStudOn extends ilAuthProviderSaml
+{
+    protected Identity $identity;
+
+    /**
+     * @inheritdoc
+     */
+    public function doAuthentication(\ilAuthStatus $status): bool
+    {
+        global $DIC;
+
+        if (!is_array($this->attributes) || 0 === count($this->attributes)) {
+            $this->getLogger()->warning('Could not parse any attributes from SAML response.');
+            $this->handleAuthenticationFail($status, 'auth_shib_not_configured');
+            return false;
+        }
+
+        try {
+            // get the uid attribute
+            $this->uid = $this->attributes['urn:mace:dir:attribute-def:uid'][0];
+
+            // needed since ILIAS 5.4.10
+            if (empty($this->uid)) {
+                $this->uid = $this->attributes['urn:oid:0.9.2342.19200300.100.1.1'][0];
+            }
+
+
+            // optionally log the request data for specific accounts
+            $this->debugLogin();
+
+            // check shibboleth session
+            if (empty($this->uid)) {
+                $this->getLogger()->warning('Uid attribute is not set in SAML data.');
+                $this->handleAuthenticationFail($status, 'auth_shib_not_configured');
+                return false;
+            }
+
+            // optionally switch the identity to another user for testing purposes
+            if ($this->uid == ilCust::get('shib_switch_uid_from') 
+                && !empty(ilCust::get('shib_switch_uid_to'))) {
+                $this->uid = ilCust::get('shib_switch_uid_to');
+            }
+
+            // get the idm data for the identity
+            $this->fetchIdentity();
+            if (empty($this->identity->getPkPersistentId())) {
+                $this->getLogger()->warning('No Identity found with uid in SAML data.');
+                $this->handleAuthenticationFail($status, 'auth_shib_not_configured');
+                return false;
+            }
+            
+
+            $login = $this->findLogin();
+            // take an already selected login fon the SSO change
+            if (empty($login) && !empty($status->getSsoChangeSelectedLogin())) {
+                $login = $status->getSsoChangeSelectedLogin();
+            }
+
+            // prepare the SSO change selection
+            if (empty($login)) {
+                $logins = $DIC->fau()->user()->repo()->findLocalLoginsByName($this->identity->getGivenName(), $this->identity->getSn());
+                if (!empty($logins)) {
+                    $status->setStatus(ilAuthStatus::STATUS_SSO_CHANGE_REQUIRED);
+                    $status->setSsoChangeIdentity($this->identity->getPkPersistentId());
+                    $status->setSsoChangeLogins($logins);
+                    return false;
+                }
+            }
+
+            // generate a new login
+            if (empty($login)) {
+                $login = $DIC->fau()->user()->generateLogin($this->identity->getPkPersistentId());
+            }
+
+
+            // set and update the user object
+            if ($id = (int) ilObjUser::_lookupId($login)) {
+                // existing user account matches
+                $user = $this->getUpdatedUser($id);
+            }
+            else {
+                // check general possibility for creating accounts
+                if (!ilCust::get('shib_allow_create')) {
+                    $this->getLogger()->warning('Creation of new users from SAML authentication is prevented.');
+                    $this->handleAuthenticationFail($status, 'shib_user_not_found');
+                    $factory = new ilSamlAuthFactory();
+                    $auth = $factory->auth();
+                    $auth->logout(ILIAS_HTTP_PATH . '/login.php?cmd=force_login&reason=shib_user_not_found');
+                    return false;
+                }
+
+                // check the minimum attributes needed for new users
+                if (empty($this->identity->getGivenName()) || empty($this->identity->getSn())) {
+                    $this->getLogger()->warning('Could not create new user because firstname or lastname is missing in SAML attributes.');
+                    $this->handleAuthenticationFail($status, 'shib_data_missing');
+                    $factory = new ilSamlAuthFactory();
+                    $auth = $factory->auth();
+                    $auth->logout(ILIAS_HTTP_PATH . '/login.php?cmd=force_login&reason=shib_data_missing');
+                    return false;
+                }
+                $user = $this->getNewUser($login);
+            }
+
+            $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
+            $status->setAuthenticatedUserId($user->getId());
+            ilSession::set('used_external_auth', true);
+            return true;
+        } catch (\ilException $e) {
+            $this->getLogger()->error($e->getMessage());
+            $this->handleAuthenticationFail($status, 'err_wrong_login');
+            return false;
+        }
+    }
+
+    /**
+     * Returns the login name of a fitting account
+     *
+     * @return 	string 	found username or ''
+     */
+    protected function findLogin()
+    {
+        // First search for the identity as external account
+        if ($login = ilObjUser::_findLoginByField('ext_account', $this->identity->getPkPersistentId())) {
+            return $login;
+        }
+
+        // as a fallback search for an idle external account
+        if ($login = ilObjUser::_findLoginByField('idle_ext_account', $this->identity->getPkPersistentId())) {
+            return $login;
+        }
+        return '';
+    }
+
+    /**
+     * create and get a new studon user
+     * @param string $login
+     * @return ilObjUser
+     */
+    protected function getNewUser($login)
+    {
+        global $DIC;
+
+        // create an empty user object (this makes the user id available)
+        $userObj = new ilObjUser();
+        $userObj->create();
+
+        // set basic account data
+        $userObj->setLogin($login);
+        $userObj->setPasswd(null);
+        $userObj->setLanguage($DIC->language()->getLangKey());
+        $userObj->setAuthMode('shibboleth');
+        $userObj->setExternalAccount($this->identity->getPkPersistentId());
+
+        // can be used in test platform for limited access
+        if (ilCust::get('shib_create_limited')) {
+            $userObj->setTimeLimitUnlimited(0);
+            $userObj->setTimeLimitFrom(time() - 10);
+            $userObj->setTimeLimitUntil($DIC->fau()->tools()->convert()->dbDateToUnix(ilCust::get('shib_create_limited')));
+        } else {
+            $userObj->setTimeLimitUnlimited(1);
+            $userObj->setTimeLimitFrom(time());
+            $userObj->setTimeLimitUntil(time());
+        }
+        $userObj->setActive(1, 6);
+        $userObj->setTimeLimitOwner(7);
+        $userObj->saveAsNew();
+
+        // apply the IDM data and update the user
+        $DIC->fau()->sync()->idm()->applyIdentityToUser($this->identity, $userObj);
+
+        // write the preferences
+        $userObj->setPref('hits_per_page', $DIC->settings()->get('hits_per_page'));
+        $userObj->setPref('show_users_online', $DIC->settings()->get('show_users_online', 'y'));
+        $userObj->writePrefs();
+
+        return $userObj;
+    }
+
+
+    /**
+     * update and get an existing studon user
+     * @param int $user_id
+     * @return ilObjUser
+     * @throws ilUserException
+     */
+    protected function getUpdatedUser($user_id)
+    {
+        global $DIC;
+
+        $userObj = new ilObjUser($user_id);
+        $login = $userObj->getLogin();
+
+        // Update the login name
+        if ($login != $this->identity->getPkPersistentId() && (
+            strpos($login, 'user.') === 0 or        // rewrite local dummy users
+            strpos($login, 'vhb.') === 0            // rewrite vhb users
+        )) {
+            $userObj->updateLogin($this->identity->getPkPersistentId());
+        }
+
+        // set the authentication mode to shibboleth
+        // this will cause the profile fields to be updated in applyIdentityToUser
+        $userObj->setAuthMode("shibboleth");
+        $userObj->setExternalAccount($this->identity->getPkPersistentId());
+        $userObj->setIdleExtAccount(null);
+
+
+        // reset agreement to force a new acceptance if user is not active
+        if (!$userObj->getActive() || !$userObj->checkTimeLimit()) {
+            $userObj->setAgreeDate(null);
+        }
+
+        // activate an inactive or timed out account via shibboleth
+        // it is assumed that all users coming from shibboleth are allowed to access studon
+        $userObj->setActive(1, 6);
+        $userObj->setTimeLimitUnlimited(true);
+        $userObj->setTimeLimitOwner(7);
+
+        // apply the IDM data and update the user
+        $DIC->fau()->sync()->idm()->applyIdentityToUser($this->identity, $userObj);
+
+        return $userObj;
+    }
+
+
+    /**
+     *  Optionally log the request data for specific accounts
+     */
+    protected function debugLogin()
+    {
+        if ($log_accounts = ilCust::get('shib_log_accounts')) {
+            $log_accounts = explode(',', $log_accounts);
+            foreach ($log_accounts as $log_account) {
+                if ($this->uid == trim($log_account)) {
+                    require_once "include/inc.debug.php";
+                    log_request();
+                    log_server();
+                }
+            }
+        }
+    }
+
+    /**
+     * Fetch the idm data either from database or from shibboleth attributes
+     * @param   string  $a_uid     user id to be used (optional)
+     */
+    protected function fetchIdentity($a_uid = '')
+    {
+        global $DIC;
+        $this->identity = $DIC->fau()->staging()->repo()->getIdentity(empty($a_uid) ? $this->uid : $a_uid);
+        if (!isset($this->identity)) {
+            $this->identity = Identity::model();
+        }
+    }
+}

--- a/Services/User/classes/Profile/class.ilUserProfile.php
+++ b/Services/User/classes/Profile/class.ilUserProfile.php
@@ -238,7 +238,7 @@ class ilUserProfile
                 );
 
                 if ($field_id == 'firstname' || $field_id == 'lastname') {
-                    if (isset($user) && !ilAuthUtils::isPasswordModificationEnabled($user->getAuthMode())) {
+                    if (isset($user) && !ilAuthUtils::isPasswordModificationEnabled($user->getAuthMode(true))) {
                         $text_input->setDisabled(true);
                         $text_input->setInfo($this->lng->txt('shib_updated_field'));
                     }

--- a/Services/User/classes/Profile/class.ilUserProfile.php
+++ b/Services/User/classes/Profile/class.ilUserProfile.php
@@ -226,8 +226,9 @@ class ilUserProfile
                     break;
                 }
 
+                // fau: samlAuth - disable also changing firstname and lastname if password modification is not allowed
                 $form->addItem(
-                    $this->getTextInput(
+                    $text_input = $this->getTextInput(
                         $field_id,
                         $field_definition,
                         $method,
@@ -235,6 +236,15 @@ class ilUserProfile
                         $user
                     )
                 );
+
+                if ($field_id == 'firstname' || $field_id == 'lastname') {
+                    if (isset($user) && !ilAuthUtils::isPasswordModificationEnabled($user->getAuthMode())) {
+                        $text_input->setDisabled(true);
+                        $text_input->setInfo($this->lng->txt('shib_updated_field'));
+                    }
+                }
+                // fau.
+
                 break;
 
             case 'textarea':

--- a/Services/User/classes/class.ilObjUserGUI.php
+++ b/Services/User/classes/class.ilObjUserGUI.php
@@ -399,6 +399,18 @@ class ilObjUserGUI extends ilObjectGUI
 
         $this->loadUserDefinedDataFromForm($user_object);
 
+        // fau: samlAuth - check authentication settings
+        global $DIC;
+        if ($errors = $DIC->fau()->user()->getAuthSettingErrors($user_object)) {
+            $this->tpl->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                $this->lng->txt('user_error_auth_settings_wrong')
+                . $DIC->fau()->tools()->format()->list($errors));
+            $this->form_gui->setValuesByPost();
+            $this->tpl->setContent($this->form_gui->getHtml());
+            return;
+        }
+        // fau.
+
         $user_object->create();
 
         if (ilAuthUtils::_isExternalAccountEnabled()) {
@@ -721,6 +733,18 @@ class ilObjUserGUI extends ilObjectGUI
             $this->loadValuesFromForm('update');
 
             $this->loadUserDefinedDataFromForm();
+
+            // fau: samlAuth - check authentication settings
+            global $DIC;
+            if ($this->object instanceof ilObjUser && $errors = $DIC->fau()->user()->getAuthSettingErrors($this->object)) {
+                $this->tpl->setOnScreenMessage(ilGlobalTemplateInterface::MESSAGE_TYPE_FAILURE,
+                    $this->lng->txt('user_error_auth_settings_wrong')
+                    . $DIC->fau()->tools()->format()->list($errors));
+                $this->form_gui->setValuesByPost();
+                $this->tpl->setContent($this->form_gui->getHtml());
+                return;
+            }
+            // fau.
 
             try {
                 $this->object->updateLogin($this->form_gui->getInput('login'));

--- a/include/inc.log_request.php
+++ b/include/inc.log_request.php
@@ -1,0 +1,276 @@
+<?php
+// fau: requestLog - request logging functions with handler class
+
+function log_request()
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeRequestLog();
+}
+
+function log_soap()
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeSoapLog();
+}
+
+function log_server()
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeServerLog();
+}
+
+function log_session()
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeSessionLog();
+}
+
+function log_cookies()
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeCookieLog();
+}
+
+function log_var(&$a_var, $a_name = '')
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeVarDump($a_var, $a_name);
+}
+
+function log_backtrace()
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeBacktrace();
+}
+
+function log_line($a_line)
+{
+    $RequestLog = RequestLog::getInstance();
+    $RequestLog->writeline($a_line);
+}
+
+class RequestLog
+{
+    private static $instance;
+
+    public $log_dir = __DIR__ . "/../data/logs";
+    
+    public $filename = "";
+
+    public $access_name = array(	1 => 'PHP_INI_USER',
+                                2 => 'PHP_INI_PERDIR',
+                                4 => 'PHP_INI_SYSTEM',
+                                7 => 'PHP_INI_ALL');
+    public $wrap = 80;
+    public $max_depth = 50;
+    public $fp = null;
+
+    /**
+     * Constructor
+     * @param string $subdir optional subdirectory
+    */
+    public function __construct($subdir = null)
+    {
+        if (!is_dir($this->log_dir)) {
+            mkdir($this->log_dir);
+        }
+
+        if (isset($subdir)) {
+            $subdir = preg_replace('[^a-zA-Z0-9]','_', $subdir);
+            $this->log_dir .= '/' . $subdir;
+
+            if (!is_dir($this->log_dir)) {
+                mkdir($this->log_dir);
+            }
+        }
+
+        list($usec, $sec) = explode(" ", microtime());
+        $this->filename = date("d-m-Y_H-i-s", $sec) . "_" . substr($usec, 2) . ".html";
+    }
+    
+    
+    /**
+    * Get instance of the standard request log
+     * @return self
+    */
+    public static function getInstance()
+    {
+        if (!isset(self::$instance)) {
+            $c = __CLASS__;
+            self::$instance = new $c;
+        }
+
+        return self::$instance;
+    }
+
+    /**
+    * write request data to the log file
+    */
+    public function writeRequestLog()
+    {
+        $this->write($this->getNamedAssocDump($_GET, '$_GET'));
+        $this->write($this->getNamedAssocDump($_POST, '$_POST'));
+        $this->write($this->getNamedAssocDump($_COOKIE, '$_COOKIE'));
+        $this->write($this->getNamedAssocDump($_FILES, '$_FILES'));
+        $this->write($this->getNamedAssocDump($_SERVER, '$_SERVER'));
+    }
+
+    /**
+    * write a SOAP request to the log file
+    */
+    public function writeSoapLog()
+    {
+        $this->write($this->getNamedAssocDump($_GET, '$_GET'));
+        $this->writeRawInput();
+        $this->write($this->getNamedAssocDump($_SERVER, '$_SERVER'));
+    }
+
+    /**
+    * write request data to the log file
+    */
+    public function writeServerLog()
+    {
+        $this->write($this->getNamedAssocDump($_SERVER, '$_SERVER'));
+        $this->write($this->getNamedIniDump('PHP_INI'));
+    }
+    
+    /**
+    * write session data to the log file
+    */
+    public function writeSessionLog()
+    {
+        $this->write($this->getNamedAssocDump($_SESSION, '$_SESSION'));
+    }
+
+    /**
+     * write cookie data to the log file
+     */
+    public function writeCookieLog()
+    {
+        $this->write($this->getNamedAssocDump($_COOKIE, '$_COOKIE'));
+    }
+
+    /**
+    * write  variable to the log file
+    */
+    public function writeVarDump(&$a_var, $a_name = '')
+    {
+        if ($a_name) {
+            $a_name = '<b>' . $a_name . ': </b>';
+        }
+        $this->write("<pre>" . $a_name . $this->getVarDump($a_var) . "</pre>\n");
+    }
+
+    /**
+    * write a backtrace to the log file
+    */
+    public function writeBacktrace()
+    {
+        $this->write('<pre>' . htmlspecialchars($this->getBacktrace()) . '</pre>');
+    }
+
+    /**
+    * write a line
+    */
+    public function writeLine($a_line)
+    {
+        $this->write($a_line . '<br/>');
+    }
+
+    /**
+    * write the raw input
+    */
+    public function writeRawInput()
+    {
+        $input = file_get_contents('php://input');
+        $this->write('<pre><h1>Raw Input</h1>' . htmlspecialchars($input) . '</pre><br/>');
+    }
+
+    /**
+    * Write a string to the log file
+    * create the log file if it does not exist
+    */
+    private function write($a_string)
+    {
+        if (!isset($this->fp)) {
+            $this->fp = fopen($this->log_dir . "/" . $this->filename, 'w');
+            fwrite($this->fp, $this->getStyles());
+        }
+        fwrite($this->fp, $a_string);
+    }
+
+    private function getStyles()
+    {
+        $ret = "<style>\n"
+            . "body, h1, th, td {font-family: monospace;} \n"
+            . "</style><br>\n";
+            
+        return $ret;
+    }
+    
+    private function getNamedIniDump($a_title)
+    {
+        $ret = '<h1>' . $a_title . '</h1>' . "\n";
+        $ret .= '<table border="1" cellspacing="0" cellpadding="2">' . "\n";
+        $ret .= '<th>Key</th><th>Global Value</th><th>Local Value</th><th>Access</th>' . "\n";
+
+        $ini = ini_get_all();
+        foreach ($ini as $key => $values) {
+            $ret .= '<tr><td>' . $key . '</td>' . "\n";
+            $ret .= '<td>' . wordwrap($values['global_value'] ?? '', floor($this->wrap / 2), "\n", 1) . '&nbsp;</td>' . "\n";
+            $ret .= '<td>' . wordwrap($values['local_value'] ?? '', floor($this->wrap / 2), "\n", 1) . '&nbsp;</td>' . "\n";
+            $ret .= '<td>' . ($this->access_name[$values['access']] ?? $values['access'] ). '&nbsp;</td></tr>' . "\n";
+        }
+        $ret .= '</table>' . "\n";
+
+        return $ret;
+    }
+    
+    
+    private function getNamedAssocDump(&$a_var, $a_title)
+    {
+        $ret = '<h1>' . $a_title . '</h1>' . "\n";
+        $ret .= $this->getAssocDump($a_var);
+        return $ret;
+    }
+
+    private function getAssocDump(&$a_var, $a_depth = 0)
+    {
+        if ($a_depth > $this->max_depth) {
+            return '';
+        } elseif (count($a_var)) {
+            $ret = '<table border="1" cellspacing="0" cellpadding="2">' . "\n";
+            $ret .= '<th>Key</th><th>Value</th>' . "\n";
+            foreach ($a_var as $key => $value) {
+                $ret .= '<tr><td>' . $key . '</td>' . "\n";
+                
+                if (is_array($value)) {
+                    $ret .= '<td>' . $this->getAssocDump($value) . '</td></tr>' . "\n";
+                } else {
+                    $ret .= '<td>' . wordwrap($this->getVarDump($value), $this->wrap, "\n", 1) . '&nbsp;</td></tr>' . "\n";
+                }
+            }
+            $ret .= '</table>' . "\n";
+            
+            return $ret;
+        }
+    }
+    
+    private function getVarDump(&$a_var)
+    {
+        return print_r($a_var, true);
+    }
+
+    private function getBacktrace()
+    {
+        $i = 0;
+        foreach (debug_backtrace() as $step) {
+            if ($i > 0) {
+                $backtrace .= '[' . $i . '] ' . $step['file'] . ' ' . $step['line'] . ': ' . $step['function'] . "()\n";
+            }
+            $i++;
+        }
+        $backtrace .= '[' . $i . '] ' . $_SERVER['REQUEST_URI'];
+        return $backtrace;
+    }
+}

--- a/saml_login.php
+++ b/saml_login.php
@@ -1,0 +1,4 @@
+<?php
+/* fau: samlAuth - additional login script for backward compatibility to studon 5.1. */
+
+include_once('saml.php');

--- a/saml_logout.php
+++ b/saml_logout.php
@@ -1,0 +1,4 @@
+<?php
+/* fau: samlAuth - additional logout script for backward compatibility to studon 5.1. */
+
+include_once('saml.php');


### PR DESCRIPTION
Die Anpassungen **samlAuth** und **samlChange** sind eng miteinander verflochten und daher habe ich dafür einen gemeinsamen Pull Request erzeugt.

Teile von samlChange (z.B. in ilObjUser) waren schon übernommen. Zusätzlich wurde die Anpassung **requestLog** mit aufgenommen. Sie wird für die Custom-Ini-Einstellung „shib_log_accounts“ benötigt, mit der man für ausgewählte Identites die Authentifizierung loggen kann.

Ich schreibe gleich noch eine Mail dazu.