### PR TITLE
footer perm url white and links formatting

### DIFF
--- a/Customizing/global/skin/studon9skin/studon9style/studon9style.css
+++ b/Customizing/global/skin/studon9skin/studon9style/studon9style.css
@@ -6546,6 +6546,17 @@ footer {
 .il-maincontrols-footer .il-footer-content div {
   
 }
+
+.il-footer-permanent-url button{
+  color:white;
+  margin-bottom:10px;  
+}
+
+.il-footer-permanent-url button:hover{
+  color:white;  
+  text-decoration: underline;
+}
+
 .il-maincontrols-footer .il-footer-links ul {
   list-style: none;
   padding: 0px;
@@ -6563,19 +6574,21 @@ footer {
   color: white;
   text-decoration:underline;
 }
+
+.il-maincontrols-footer .il-footer-links ul{
+  margin-right:20px;
+}
+
 .il-maincontrols-footer .il-footer-links li button {
   vertical-align: baseline;
 }
-.il-maincontrols-footer .il-footer-links li:first-child:before {
-  content: "·";
-  margin-right: 10px;
+
+.il-maincontrols-footer .il-footer-links li {  
+  padding:0 10px 0 10px;
 }
-.il-maincontrols-footer .il-footer-links li:after {
-  content: "·";
-  margin-left: 10px;
-}
+
 .il-maincontrols-footer .il-footer-links li:last-child:after {
-  content: " ";
+  content: "";
 }
 .il-maincontrols-footer .il-footer-permanent-url {
   margin-right: 3px;


### PR DESCRIPTION
"link kopieren"-link jetzt weiß und gut positioniert.
punkte bei kontakt etc. entfernt (empfehlung von medienteam)