### PR TITLE
add error_reporting command

### DIFF
--- a/Services/Init/classes/class.ilInitialisation.php
+++ b/Services/Init/classes/class.ilInitialisation.php
@@ -1180,7 +1180,12 @@ class ilInitialisation
      */
     protected static function handleDevMode(): void
     {
+        // fau: ExtDevMode - Extend Dev Mode possibilities
+        if(DEVMODE == 2)
+        error_reporting(6133);
+        else
         error_reporting(-1);
+        // fau.
     }
 
     protected static bool $already_initialized = false;

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -17,9 +17,7 @@
  *********************************************************************/
 
 declare(strict_types=1);
-// fau: fixErrRep - set error-reporting if php.ini settings are
-error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
-// fau.
+
 use ILIAS\Object\ilObjectDIC;
 use ILIAS\Object\Properties\ObjectReferenceProperties\ObjectReferenceProperties;
 

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -17,7 +17,7 @@
  *********************************************************************/
 
 declare(strict_types=1);
-
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 use ILIAS\Object\ilObjectDIC;
 use ILIAS\Object\Properties\ObjectReferenceProperties\ObjectReferenceProperties;
 

--- a/Services/Object/classes/class.ilObject.php
+++ b/Services/Object/classes/class.ilObject.php
@@ -17,7 +17,9 @@
  *********************************************************************/
 
 declare(strict_types=1);
+// fau: fixErrRep - set error-reporting if php.ini settings are
 error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
+// fau.
 use ILIAS\Object\ilObjectDIC;
 use ILIAS\Object\Properties\ObjectReferenceProperties\ObjectReferenceProperties;
 


### PR DESCRIPTION
die php error_reporting umgebungsvariable wird von ilias ignoriert und es kommen E_DEPRECATED-Meldungen zutage.
Das kommt NUR im DEVMODE, stört aber unsere gesamte Testerei auf studon-test z.b. und zukünftig.

Im scharfen Betrieb wird diese Zeile zu keiner Kollision führen, da eh in der php.ini genau diese Einstellungen vorhanden sind. 

Was verhindert diese Zeile?
wenn wir externe links haben, bei denen kein // drin steht oder ein mailto eingesetzt wird, schmeißt ohne diese Zeile
der Server/Whoops einen Fehler mit strtolower deprecated. 
