### PR TITLE
fix: feedbackdate check

### DIFF
--- a/Modules/Exercise/Assignment/class.ilExAssignmentEditorGUI.php
+++ b/Modules/Exercise/Assignment/class.ilExAssignmentEditorGUI.php
@@ -975,7 +975,9 @@ class ilExAssignmentEditorGUI
         if (isset($_POST["fb"]) ? $_POST["fb"] : 0 || $this->type_has_own_feedback) {
             $a_ass->setFeedbackCron($a_input["fb_cron"]); // #13380
             $a_ass->setFeedbackDate($a_input["fb_date"]);
-            $a_ass->setFeedbackDateCustom($a_input["fb_date_custom"]);
+            if (isset($a_input["fb_date_custom"])) {
+                $a_ass->setFeedbackDateCustom($a_input["fb_date_custom"]);
+            }
         }
         // fau.
 


### PR DESCRIPTION
fix von fehlermeldung wenn für musterlösung kein datum notwendig ist, z.b. bei "nach dem abgabetermin" bzw. "nach der abgabe"