### PR TITLE
improve devmode 2 handling

### DIFF
--- a/Services/COPage/Editor/UI/Init.php
+++ b/Services/COPage/Editor/UI/Init.php
@@ -55,7 +55,7 @@ class Init
             $lng->toJS($l);
         }
 
-        if (DEVMODE == 1) {
+        if (DEVMODE >= 1) {
             $main_tpl->addJavaScript("./node_modules/tinymce/tinymce.js");
         } else {
             $main_tpl->addJavaScript("./node_modules/tinymce/tinymce.min.js");

--- a/Services/Help/GlobalScreen/classes/class.ilHelpGSToolProvider.php
+++ b/Services/Help/GlobalScreen/classes/class.ilHelpGSToolProvider.php
@@ -115,7 +115,7 @@ class ilHelpGSToolProvider extends AbstractDynamicToolProvider
         $help_gui->initHelp($main_tpl, $ctrl->getLinkTargetByClass("ilhelpgui", "", "", true));
 
         $html = "";
-        if ((defined("OH_REF_ID") && (int) OH_REF_ID > 0) || (defined('DEVMODE') && (int) DEVMODE === 1)) {
+        if ((defined("OH_REF_ID") && (int) OH_REF_ID > 0) || (defined('DEVMODE') && (int) DEVMODE >= 1)) {
             $html = "<div class='ilHighlighted small'>Screen ID: " . $help_gui->getScreenId() . "</div>";
         }
 

--- a/Services/Init/classes/class.ilErrorHandling.php
+++ b/Services/Init/classes/class.ilErrorHandling.php
@@ -263,7 +263,7 @@ class ilErrorHandling
 
     protected function isDevmodeActive(): bool
     {
-        return defined('DEVMODE') && (int) DEVMODE === 1;
+        return defined('DEVMODE') && (int) DEVMODE >= 1;
     }
 
     protected function defaultHandler(): HandlerInterface

--- a/Services/MediaObjects/Video/Service/class.GUIService.php
+++ b/Services/MediaObjects/Video/Service/class.GUIService.php
@@ -92,7 +92,7 @@ class GUIService
                 $this->tpl->setOnScreenMessage('failure', $lng->txt("mob_no_extraction_possible"), true);
             }
         } catch (\ilException $e) {
-            if (DEVMODE === 1) {
+            if (DEVMODE >= 1) {
                 $ret = \ilFFmpeg::getLastReturnValues();
                 $add = (is_array($ret) && count($ret) > 0)
                     ? "<br />" . implode("<br />", $ret)


### PR DESCRIPTION
abfragen-änderungen von devmode === 1 auf devmode >= 1.
da wir devmode 2 einfgeführt haben.
devmode 1 hatte noch das problem dass es deprecated warnungen anzeigte und somit war kein echte fehlersuche möglich. 
devmode 2 zeigt keine deprecated warnung, und error-meldungen im browser-fenster (whoops)