### PR TITLE
Fix SAML Logout

### DIFF
--- a/Services/Init/classes/class.ilStartUpGUI.php
+++ b/Services/Init/classes/class.ilStartUpGUI.php
@@ -1443,15 +1443,6 @@ class ilStartUpGUI implements ilCtrlBaseClassInterface, ilCtrlSecurityInterface
             ]
         );
 
-        // fau: samlAuth - do SAML logout when auth mode is Shibboleth
-        if ($used_external_auth_mode && (int) $this->user->getAuthMode(true) === ilAuthUtils::AUTH_SHIBBOLETH) {
-            $this->logger->info('Redirecting user to SAML logout script');
-            $this->ctrl->redirectToURL(
-                'saml.php?action=logout&logout_url=' . urlencode(ilUtil::_getHttpPath() . '/login.php')
-            );
-        }
-        // fau.
-
         // reset cookie
         ilUtil::setCookie("ilClientId", "");
 

--- a/Services/Saml/classes/class.ilAuthProviderSamlStudOn.php
+++ b/Services/Saml/classes/class.ilAuthProviderSamlStudOn.php
@@ -112,7 +112,7 @@ class ilAuthProviderSamlStudOn extends ilAuthProviderSaml
 
             $status->setStatus(ilAuthStatus::STATUS_AUTHENTICATED);
             $status->setAuthenticatedUserId($user->getId());
-            ilSession::set('used_external_auth', true);
+            ilSession::set('used_external_auth_mode', $this->getTriggerAuthMode());
             return true;
         } catch (\ilException $e) {
             $this->getLogger()->error($e->getMessage());


### PR DESCRIPTION
Mit diesem PR wird beim Abmelden von ILIAS auch ein SSO-Logout durchgeführt. Der Patch in ilStartUpGUI ist dafür nicht mehr nötig. Das macht mittlerweile ein Event-Handler vom ILIAS-Kern. Allerdings muss dafür die Session-Variable "used_external_auth_mode" richtig gesetzt sein. In früheren ILIAS-Versionen genügt es, sie auf "true" zu setzen, jetzt benötigt sie einen String mit der ID des Authentifizierungsmodus. In der Authentifizierungsklasse von StudOn war das noch nicht geändert.

Bitte testet es auch einmal mit vhb-Anmeldungen - das kann ich lokal schlecht nachstellen.
