### PR TITLE
extend plugin-object-scan for type definitions - special for exautoscore

### DIFF
--- a/Modules/Exercise/Assignment/Types/GUI/classes/class.ilExAssignmentTypesGUI.php
+++ b/Modules/Exercise/Assignment/Types/GUI/classes/class.ilExAssignmentTypesGUI.php
@@ -33,22 +33,68 @@ class ilExAssignmentTypesGUI
      */
     protected function getActivePlugins() {
         if (!isset($this->plugins)) {
-            $this->plugins = [];
             global $DIC;
-            $this->component_repository = $DIC["component.repository"];
-            $this->component_factory = $DIC["component.factory"];
-            if($this->component_repository->hasPluginSlotId("exahsk")) {
-                $names = $this->component_factory->getActivePluginsInSlot('exashk');
-            }
-            else {
-                $names = [];
-            }
+            
+            $this->plugins = [];
+            
+            try {
+                // Methode 1: Über Component Repository
+                $component_repo = $DIC["component.repository"];
                 
-            foreach ($names as $name) {
-                $this->plugins[] = $this->component_repository->getPluginById($name);
+                // Versuche verschiedene Ansätze
+                if (method_exists($component_repo, 'getPlugins')) {
+                    $plugins_generator = $component_repo->getPlugins();
+                    $all_plugins = iterator_to_array($plugins_generator);
+                    
+                    foreach ($all_plugins as $plugin_info) {
+                        // Versuche verschiedene Eigenschaften zu lesen
+                        $plugin_id = method_exists($plugin_info, 'getId') ? $plugin_info->getId() : 'unknown';
+                        $plugin_name = method_exists($plugin_info, 'getName') ? $plugin_info->getName() : 'unknown';
+                        $is_active = method_exists($plugin_info, 'isActive') ? $plugin_info->isActive() : false;
+                        
+                        // Suche nach ExAutoScore
+                        if (strpos(strtolower($plugin_id), 'exautoscore') !== false || 
+                            strpos(strtolower($plugin_name), 'exautoscore') !== false) {
+                            
+                            if ($is_active) {
+                                try {
+                                    $component_factory = $DIC["component.factory"];
+                                    $plugin_instance = $component_factory->getPlugin($plugin_id);
+                                    $this->plugins[] = $plugin_instance;
+                                } catch (Exception $e) {
+                                    // Plugin-Instanziierung fehlgeschlagen
+                                }
+                            }
+                        }
+                    }
+                }
+                
+            } catch (Exception $e) {
+                // Component Repository Ansatz fehlgeschlagen
+            }
+            
+            // Fallback: Direkte Plugin-Instanziierung
+            if (empty($this->plugins)) {
+                $plugin_path = ILIAS_ABSOLUTE_PATH . '/Customizing/global/plugins/Modules/Exercise/AssignmentHook/ExAutoScore/classes/class.ilExAutoScorePlugin.php';
+                
+                if (file_exists($plugin_path)) {
+                    require_once($plugin_path);
+                    
+                    if (class_exists('ilExAutoScorePlugin')) {
+                        try {
+                            $plugin = ilExAutoScorePlugin::getInstance();
+                            
+                            // Prüfe Plugin-Status
+                            if (method_exists($plugin, 'isActive') && $plugin->isActive()) {
+                                $this->plugins[] = $plugin;
+                            }
+                        } catch (Exception $e) {
+                            // Direkte Plugin-Instanziierung fehlgeschlagen
+                        }
+                    }
+                }
             }
         }
-
         return $this->plugins;
     }
     // fau.

--- a/Modules/Exercise/Assignment/Types/class.ilExAssignmentTypes.php
+++ b/Modules/Exercise/Assignment/Types/class.ilExAssignmentTypes.php
@@ -39,18 +39,66 @@ class ilExAssignmentTypes
      */
     protected function getActivePlugins() {
         if (!isset($this->plugins)) {
-            $this->plugins = [];
             global $DIC;
-            $this->component_repository = $DIC["component.repository"];
-            $this->component_factory = $DIC["component.factory"];
-            if($this->component_repository->hasPluginSlotId("exahsk")) {
-                $names = $this->component_factory->getActivePluginsInSlot('exashk');
+            
+            $this->plugins = [];
+            
+            try {
+                // Methode 1: Über Component Repository
+                $component_repo = $DIC["component.repository"];
+                
+                // Versuche verschiedene Ansätze
+                if (method_exists($component_repo, 'getPlugins')) {
+                    $plugins_generator = $component_repo->getPlugins();
+                    $all_plugins = iterator_to_array($plugins_generator);
+                    
+                    foreach ($all_plugins as $plugin_info) {
+                        // Versuche verschiedene Eigenschaften zu lesen
+                        $plugin_id = method_exists($plugin_info, 'getId') ? $plugin_info->getId() : 'unknown';
+                        $plugin_name = method_exists($plugin_info, 'getName') ? $plugin_info->getName() : 'unknown';
+                        $is_active = method_exists($plugin_info, 'isActive') ? $plugin_info->isActive() : false;
+                        
+                        // Suche nach ExAutoScore
+                        if (strpos(strtolower($plugin_id), 'exautoscore') !== false || 
+                            strpos(strtolower($plugin_name), 'exautoscore') !== false) {
+                            
+                            if ($is_active) {
+                                try {
+                                    $component_factory = $DIC["component.factory"];
+                                    $plugin_instance = $component_factory->getPlugin($plugin_id);
+                                    $this->plugins[] = $plugin_instance;
+                                } catch (Exception $e) {
+                                    // Plugin-Instanziierung fehlgeschlagen
+                                }
+                            }
+                        }
+                    }
+                }
+                
+            } catch (Exception $e) {
+                // Component Repository Ansatz fehlgeschlagen
             }
-            else {
-                $names = [];
-            }
-            foreach ($names as $name) {
-                $this->plugins[] = $this->component_repository->getPluginById($name);
+            
+            // Fallback: Direkte Plugin-Instanziierung
+            if (empty($this->plugins)) {
+                $plugin_path = ILIAS_ABSOLUTE_PATH . '/Customizing/global/plugins/Modules/Exercise/AssignmentHook/ExAutoScore/classes/class.ilExAutoScorePlugin.php';
+                
+                if (file_exists($plugin_path)) {
+                    require_once($plugin_path);
+                    
+                    if (class_exists('ilExAutoScorePlugin')) {
+                        try {
+                            $plugin = ilExAutoScorePlugin::getInstance();
+                            
+                            // Prüfe Plugin-Status
+                            if (method_exists($plugin, 'isActive') && $plugin->isActive()) {
+                                $this->plugins[] = $plugin;
+                            }
+                        } catch (Exception $e) {
+                            // Direkte Plugin-Instanziierung fehlgeschlagen
+                        }
+                    }
+                }
             }
         }
         return $this->plugins;

--- a/Modules/Exercise/Assignment/class.ilExAssignmentEditorGUI.php
+++ b/Modules/Exercise/Assignment/class.ilExAssignmentEditorGUI.php
@@ -191,6 +191,7 @@ class ilExAssignmentEditorGUI
                     $type_gui = $this->type_guis->getByClassName($class);
                     $type_gui->setAssignment($this->assignment);
                     $ilCtrl->forwardCommand($type_gui);
+                    return;
                 }
                 // fau.
                 $this->{$cmd . "Object"}();
@@ -703,8 +704,11 @@ class ilExAssignmentEditorGUI
             }
 
             // fau: exAssHook - change feedback upload only if it is included
-            if ($this->assignment->getFeedbackFile() && !empty($a_form->getItemByPostVar("fb_file"))) {
-                $a_form->getItemByPostVar("fb_file")->setRequired(false); // #15467
+            if ($this->assignment->getFeedbackFile()) {
+                $fb_file_item = $a_form->getItemByPostVar("fb_file");
+                if ($fb_file_item !== null) {
+                    $fb_file_item->setRequired(false); // #15467
+                }
             }
             // fau.
         }
@@ -897,7 +901,8 @@ class ilExAssignmentEditorGUI
                     $res["fb_date"] = $a_form->getInput("fb_date");
                     $res["fb_date_custom"] = $time_fb_custom_date;
 
-                    if ($_FILES["fb_file"]["tmp_name"]) {
+                    // Nur wenn fb_file auch existiert (nicht bei deinem Plugin)
+                    if (isset($_FILES["fb_file"]) && $_FILES["fb_file"]["tmp_name"]) {
                         $res["fb_file"] = $_FILES["fb_file"];
                     }
                 }
@@ -1175,14 +1180,16 @@ class ilExAssignmentEditorGUI
         // global feedback
         // fau: exAssHook - don't check feedback file it type has its own general feedback
         if (!$this->type_has_own_feedback && $this->assignment->getFeedbackFile()) {
-            $a_form->getItemByPostVar("fb")->setChecked(true);
-            $a_form->getItemByPostVar("fb_file")->setValue(basename($this->assignment->getGlobalFeedbackFilePath()));
-            $a_form->getItemByPostVar("fb_file")->setRequired(false); // #15467
-            $a_form->getItemByPostVar("fb_file")->setInfo(
-                // #16400
-                '<a href="' . $ilCtrl->getLinkTarget($this, "downloadGlobalFeedbackFile") . '">' .
-                $lng->txt("download") . '</a>'
-            );
+            $fb_file_item = $a_form->getItemByPostVar("fb_file");
+            if ($fb_file_item !== null) {
+                $fb_file_item->setValue(basename($this->assignment->getGlobalFeedbackFilePath()));
+                $fb_file_item->setRequired(false); // #15467
+                $fb_file_item->setInfo(
+                    // #16400
+                    '<a href="' . $ilCtrl->getLinkTarget($this, "downloadGlobalFeedbackFile") . '">' .
+                    $lng->txt("download") . '</a>'
+                );
+            }
         }
         // fau.
         $a_form->getItemByPostVar("fb_cron")->setChecked($this->assignment->hasFeedbackCron());


### PR DESCRIPTION
nötig für die darstellung von übungseinheiten in der übung namens
programmieraufgaben (einzelnutzer)
programmieraufgaben(team)