### PR TITLE
fix: call testsession now properly

### DIFF
--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -109,9 +109,12 @@ class ilTestScoring
                 /** @var  ilTestEvaluationUserData $userdata */
                 include_once("./Services/Tracking/classes/class.ilLPStatusWrapper.php");
                 ilLPStatusWrapper::_updateStatus($this->test->getId(), $userdata->getUserID());
-
+                
                 require_once ('./Modules/Exercise/AssignmentTypes/classes/class.ilExAssTypeTestResultAssignment.php');
-                ilExAssTypeTestResultAssignment::updateAssignments($this->test, $factory->getSession($active_id));
+                global $DIC;
+                $testSession = new ilTestSession($this->db, $DIC->user());
+                $testSession->loadFromDb($active_id);
+                ilExAssTypeTestResultAssignment::updateAssignments($this->test, $testSession);
             }
         }
 

--- a/Modules/Test/classes/class.ilTestScoring.php
+++ b/Modules/Test/classes/class.ilTestScoring.php
@@ -112,9 +112,11 @@ class ilTestScoring
                 
                 require_once ('./Modules/Exercise/AssignmentTypes/classes/class.ilExAssTypeTestResultAssignment.php');
                 global $DIC;
-                $testSession = new ilTestSession($this->db, $DIC->user());
-                $testSession->loadFromDb($active_id);
-                ilExAssTypeTestResultAssignment::updateAssignments($this->test, $testSession);
+                $user = $DIC->user();
+                $session_factory = new ilTestSessionFactory($this->test, $this->db, $user);
+
+                require_once ('./Modules/Exercise/AssignmentTypes/classes/class.ilExAssTypeTestResultAssignment.php');
+                ilExAssTypeTestResultAssignment::updateAssignments($this->test, $session_factory->getSession($active_id));
             }
         }
 


### PR DESCRIPTION
fix von Error thrown with message "Call to undefined method ilTestEvaluationFactory::getSession()"

getsession existiert in factory nicht, 'umweg' jetzt über testsession generierung. 
global $DIC nötig da vorhandene variablen zu stark durchiteriert werden müssten. 