### PR TITLE
fix exasstest zero grading

### DIFF
--- a/Modules/Exercise/Assignment/PropertyAndActionBuilderUI.php
+++ b/Modules/Exercise/Assignment/PropertyAndActionBuilderUI.php
@@ -1040,7 +1040,8 @@ class PropertyAndActionBuilderUI
                     $current_status = $ass->getMemberStatus($first_user);
 
                     // Publish if not yet published
-                    if ($current_status->getStatus() === 'notgraded' || empty($current_status->getMark())) {
+                    // Note: Use strict comparison against empty string, not empty(), because mark can be "0"
+                    if ($current_status->getStatus() === 'notgraded' || $current_status->getMark() === '') {
                         try {
                             global $DIC;
                             $test = new \ilObjTest($test_ref_id, true);


### PR DESCRIPTION
when a user had 0 mark in his test result, the 'all' overview in the exercise overview had an infinite loop. 
this fix will erase this behaviour with a better check. 