### PR TITLE
extend campouserexport with 2 new sheets, language center

### DIFF
--- a/Customizing/global/lang/ilias_de.lang.local
+++ b/Customizing/global/lang/ilias_de.lang.local
@@ -567,6 +567,10 @@ fau#:#fau_export_course_members_base_info#:#Bereich im StudOn-Magazin, für den 
 fau#:#fau_export_course_members_with_groups#:#Mit Gruppen
 fau#:#fau_export_course_members_with_groups_info#:#Exportiert auch die Teilnehmer/innen von Gruppen in diesem Bereich oder innerhalb der Kurse
 fau#:#fau_export_course_members_failed#:#Die Kursteilnehmer/innen konnten nicht exportiert werden!
+fau#:#fau_export_column_short_text#:#Mitglied Kurztext
+fau#:#fau_export_sheet_persons#:#Nach Personen
+fau#:#fau_export_sheet_courses#:#Nach Lehrveranstaltungen
+fau#:#fau_export_sheet_waiting#:#Nach Warteliste
 fau#:#fair_autofill_cron#:#Chancengleiche Anmeldungen vergeben
 fau#:#fair_autofill_cron_info#:#Nach Ablauf der chancengleichen Anmeldung werden die freien Plätze in Gruppen und Kursen automatisch vergeben.
 fau#:#fair_autofill_cron_result#:#Vergebene Plätze: %s

--- a/Customizing/global/lang/ilias_en.lang.local
+++ b/Customizing/global/lang/ilias_en.lang.local
@@ -569,6 +569,10 @@ fau#:#fau_export_course_members_base_info#:#Area in StudOn magazine for which th
 fau#:#fau_export_course_members_with_groups#:#With Groups###
 fau#:#fau_export_course_members_with_groups_info#:#Exports also the participants of groups in this area or within the courses###
 fau#:#fau_export_course_members_failed#:#The course participants could not be exported.
+fau#:#fau_export_column_short_text#:#Member Short Text
+fau#:#fau_export_sheet_persons#:#By Persons
+fau#:#fau_export_sheet_courses#:#By Courses
+fau#:#fau_export_sheet_waiting#:#By Waiting List
 fau#:#fair_autofill_cron#:#Allocate places to applications for admission with equal chances of gaining a place
 fau#:#fair_autofill_cron_info#:#After the end of the phase during which all applicants have equal chances of obtaining a place, free places in groups and courses are allocated automatically.
 fau#:#fair_autofill_cron_result#:#Allocated places: %s

--- a/Services/FAU/Ilias/CourseUsersExport.php
+++ b/Services/FAU/Ilias/CourseUsersExport.php
@@ -11,6 +11,9 @@ use FAU\Study\Data\Term;
 
 class CourseUsersExport extends AbstractExport
 {
+    /** @var int Excel row number where data rows start (after header) */
+    private const EXCEL_FIRST_DATA_ROW = 2;
+
     protected Container $dic;
     protected \ilLanguage $lng;
 
@@ -75,14 +78,15 @@ class CourseUsersExport extends AbstractExport
      */
     public function exportCoursesUsers(string $type = self::TYPE_EXCEL, ?int $filter_obj_id = null) : string
     {
+        // Use single term if only one is provided, otherwise use null (exports across all terms)
         if (count($this->terms) == 1) {
             $term = reset($this->terms);
         }
         else {
             $term = null;
         }
-        
-        // get the membersips/waiting lists from courses or groups within the category
+
+        // get the memberships/waiting lists from courses or groups within the category
         foreach ($this->terms as $term) {
             foreach ($this->dic->fau()->ilias()->repo()->findCoursesOrGroups($this->cat_ref_id, $term, $this->export_with_groups) as $container) {
                 if (isset($filter_obj_id) || $this->dic->access()->checkAccess('manage_members', '', $container->getRefId())
@@ -97,13 +101,16 @@ class CourseUsersExport extends AbstractExport
         // get the users to export - either from the given object or from the courses or groups within the category
         if (isset($filter_obj_id)) {
             $obj_members = $this->dic->fau()->ilias()->repo()->getObjectsMemberIds([$filter_obj_id]);
-            $obj_waiting = $this->dic->fau()->ilias()->repo()->getObjectsMemberIds([$filter_obj_id]);
+            $obj_waiting = $this->dic->fau()->ilias()->repo()->getObjectsWaitingIds([$filter_obj_id]);
             $user_ids = array_unique(array_merge(array_keys($obj_members), array_keys($obj_waiting)));
         }
         else {
             $user_ids = array_unique(array_merge(array_keys($this->users_member), array_keys($this->users_waiting)));
         }
         $this->users = $this->dic->fau()->user()->getUserData($user_ids, $this->cat_ref_id);
+
+        // Set title for first worksheet
+        $this->spreadsheet->getActiveSheet()->setTitle($this->lng->txt('fau_export_sheet_persons'));
 
         $columns = array(
             'login' => $this->lng->txt('login'),
@@ -119,25 +126,189 @@ class CourseUsersExport extends AbstractExport
         );
         $mapping = $this->fillHeaderRow($columns);
 
-        $row = 2;
+        $row = self::EXCEL_FIRST_DATA_ROW;
         foreach ($this->users as $user) {
-            $data = [
-                'login' => $user->getLogin(),
-                'lastname' => $user->getLastname(),
-                'firstname' => $user->getFirstname(),
-                'gender' => $user->getGender(),
-                'email' => $user->getEmail(),
-                'matriculation' => $user->getMatriculation(),
-                'studydata' => $this->dic->fau()->user()->getStudiesText($user->getPerson(), $term),
-                'educations' => $this->dic->fau()->user()->getEducationsText($user->getEducations()),
-                'memberships' => $this->getContainersAsText($this->users_member[$user->getUserId()] ?? []),
-                'waiting_lists' =>  $this->getContainersAsText($this->users_waiting[$user->getUserId()] ?? []),
-            ];
+            // Build data array: base user data + membership-specific fields
+            $data = array_merge(
+                $this->getUserDataArray($user, $term, true),
+                [
+                    'memberships' => $this->getContainersAsText($this->users_member[$user->getUserId()] ?? []),
+                    'waiting_lists' => $this->getContainersAsText($this->users_waiting[$user->getUserId()] ?? []),
+                ]
+            );
             $this->fillRowData($data, $mapping, $row++);
         }
 
         $this->adjustSizes();
+
+        // Load shorttexts for detail worksheets (only needed for the new worksheets below)
+        // Collect all course_ids from the containers' import_ids
+        $shorttext_course_ids = [];
+        foreach ($this->containers as $container) {
+            try {
+                // getImportId() has wrong type declaration (string instead of ImportId)
+                // We catch the TypeError and skip containers without valid ImportId
+                $import_id = $container->getImportId();
+                if ($import_id !== null) {
+                    $course_id = $import_id->getCourseId();
+                    if (!empty($course_id)) {
+                        $shorttext_course_ids[] = $course_id;
+                    }
+                }
+            } catch (\TypeError $e) {
+                // Skip containers without valid ImportId (e.g., non-Campo courses)
+                continue;
+            }
+        }
+        // Load all shorttexts in one query (performance optimization)
+        $unique_course_ids = array_unique($shorttext_course_ids);
+        $course_shorttexts = $this->dic->fau()->study()->repo()->getCoursesShorttexts($unique_course_ids);
+
+        // Create additional worksheets with detailed membership and waiting list information
+        $this->createDetailWorksheet(
+            $this->lng->txt('fau_export_sheet_courses'),
+            $this->lng->txt('member'),
+            $this->users_member,
+            $course_shorttexts,
+            $term,
+            true  // include educations column
+        );
+        $this->createDetailWorksheet(
+            $this->lng->txt('fau_export_sheet_waiting'),
+            $this->lng->txt('on_waiting_list'),
+            $this->users_waiting,
+            $course_shorttexts,
+            $term,
+            false  // no educations column
+        );
+
+        // Return to the first worksheet (important for proper Excel file structure)
+        $this->spreadsheet->setActiveSheetIndex(0);
+
         return $this->buildExportFile('course_users', $type);
+    }
+
+    /**
+     * Get base user data as array for export
+     * Extracts common user fields to avoid code duplication
+     *
+     * @param UserData $user The user to extract data from
+     * @param Term|null $term Current term for study data
+     * @param bool $includeEducations Whether to include educations field
+     * @return array User data array with keys matching column names
+     */
+    protected function getUserDataArray(UserData $user, ?Term $term, bool $includeEducations = true): array
+    {
+        $data = [
+            'login' => $user->getLogin(),
+            'lastname' => $user->getLastname(),
+            'firstname' => $user->getFirstname(),
+            'gender' => $user->getGender(),
+            'email' => $user->getEmail(),
+            'matriculation' => $user->getMatriculation(),
+            'studydata' => $this->dic->fau()->user()->getStudiesText($user->getPerson(), $term),
+        ];
+
+        if ($includeEducations) {
+            $data['educations'] = $this->dic->fau()->user()->getEducationsText($user->getEducations());
+        }
+
+        return $data;
+    }
+
+    /**
+     * Create a detailed worksheet with user memberships or waiting list entries
+     * This is a generic helper method to avoid code duplication between membership and waiting list worksheets
+     *
+     * @param string $sheetTitle Title of the worksheet (e.g., "Memberships" or "Waiting Lists")
+     * @param string $courseTitleLabel Label for the course title column (e.g., "Member" or "Enrolled on Waiting List")
+     * @param array $userObjIds Array mapping user_id to obj_ids (e.g., $this->users_member or $this->users_waiting)
+     * @param array $course_shorttexts Array of shorttexts indexed by course_id
+     * @param Term|null $term Current term for study data
+     * @param bool $includeEducations Whether to include the educations column
+     */
+    protected function createDetailWorksheet(
+        string $sheetTitle,
+        string $courseTitleLabel,
+        array $userObjIds,
+        array $course_shorttexts,
+        ?Term $term,
+        bool $includeEducations = true
+    ): void {
+        // Create a new worksheet
+        $sheet = $this->spreadsheet->createSheet();
+        $sheet->setTitle($sheetTitle);
+
+        // Set the new sheet as active so fillHeaderRow() and fillRowData() write to it
+        $this->spreadsheet->setActiveSheetIndex($this->spreadsheet->getIndex($sheet));
+
+        // Define base columns
+        $columns = [
+            'shorttext' => $this->lng->txt('fau_export_column_short_text'),
+            'course_title' => $courseTitleLabel,
+            'login' => $this->lng->txt('login'),
+            'lastname' => $this->lng->txt('lastname'),
+            'firstname' => $this->lng->txt('firstname'),
+            'gender' => $this->lng->txt('gender'),
+            'email' => $this->lng->txt('email'),
+            'matriculation' => $this->lng->txt('matriculation'),
+            'studydata' => $this->lng->txt('studydata'),
+        ];
+
+        // Optionally add educations column
+        if ($includeEducations) {
+            $columns['educations'] = $this->lng->txt('fau_educations');
+        }
+
+        // Fill header row and get column mapping
+        $mapping = $this->fillHeaderRow($columns);
+
+        // Fill data rows - one row per membership/waiting list entry per user
+        $row = self::EXCEL_FIRST_DATA_ROW;
+        foreach ($this->users as $user) {
+            // Get all obj_ids for this user from the provided array
+            $obj_ids = $userObjIds[$user->getUserId()] ?? [];
+
+            foreach ($obj_ids as $obj_id) {
+                // Skip if container doesn't exist (safety check)
+                if (!isset($this->containers[$obj_id])) {
+                    continue;
+                }
+
+                $container = $this->containers[$obj_id];
+
+                // Get shorttext from our loaded array (empty string if not found or NULL)
+                $shorttext = '';
+                try {
+                    // getImportId() has wrong type declaration (string instead of ImportId)
+                    // We catch the TypeError and use empty shorttext for containers without valid ImportId
+                    $import_id = $container->getImportId();
+                    if ($import_id !== null) {
+                        $course_id = $import_id->getCourseId();
+                        if ($course_id && isset($course_shorttexts[$course_id])) {
+                            $shorttext = $course_shorttexts[$course_id];
+                        }
+                    }
+                } catch (\TypeError $e) {
+                    // Skip containers without valid ImportId - shorttext remains empty
+                    $shorttext = '';
+                }
+
+                // Build data array: course-specific fields + user data
+                $data = array_merge(
+                    [
+                        'shorttext' => $shorttext,
+                        'course_title' => $container->getTitle(),
+                    ],
+                    $this->getUserDataArray($user, $term, $includeEducations)
+                );
+
+                $this->fillRowData($data, $mapping, $row++);
+            }
+        }
+
+        // Adjust column widths for the worksheet
+        $this->adjustSizes($mapping);
     }
 
     /**

--- a/Services/FAU/Study/Repository.php
+++ b/Services/FAU/Study/Repository.php
@@ -414,6 +414,29 @@ class Repository extends RecordRepo
         return $this->getSingleRecord($query, Course::model(), $default);
     }
 
+    /**
+     * Get shorttexts for multiple courses by their IDs
+     * This is a performance-optimized method that only loads the shorttext field
+     *
+     * @param int[] $course_ids Array of course IDs to load shorttexts for
+     * @return string[] Array indexed by course_id containing the shorttext (empty string if NULL)
+     */
+    public function getCoursesShorttexts(array $course_ids) : array
+    {
+        if (empty($course_ids)) {
+            return [];
+        }
+
+        $query = "SELECT course_id, shorttext FROM fau_study_courses WHERE "
+            . $this->db->in('course_id', $course_ids, false, 'integer');
+
+        $shorttexts = [];
+        $result = $this->db->query($query);
+        while ($row = $this->db->fetchAssoc($result)) {
+            $shorttexts[(int) $row['course_id']] = (string) ($row['shorttext'] ?? '');
+        }
+        return $shorttexts;
+    }
 
     /**
      * Get the course of a planned date


### PR DESCRIPTION
2 neue tabellen für campo user export für das sprachenzentrum.
neue sprachvariablen waren notwendig.
kleine änderungen noch in rechtschreibung und kommentar nachgetragen. 
Konstante eingetragen, anstatt magic number

getestet auf studon-test, anna hat auch schon ausprobiert.