### PR TITLE
fix wrong type for getimportid

### DIFF
--- a/Services/FAU/Ilias/Data/ContainerData.php
+++ b/Services/FAU/Ilias/Data/ContainerData.php
@@ -79,7 +79,7 @@ class ContainerData
     /**
      * @return ImportId
      */
-    public function getImportId(): string
+    public function getImportId(): ImportId
     {
         return $this->import_id;
     }


### PR DESCRIPTION
falscher typ für importid. 
in der klasse wird importid als rückgabewert definiert nicht string. 
importid ist hier richtig (siehe klassendefinition am anfang der datei)

die funktion getimportid wird nur von meiner letzten anpassung für das sprachenzentrum verwendet
laut VSC, referenzen nur hier:
CourseUsersExport.php Services/FAU/Ilias
$container->getimportId();
$container->getImportId();

ContainerData wird auch nur in 
Services/FAU/Ilias/CourseUsersExport.php/CourseUsersExport
und 
Services/FAU/Ilias/Repository.php/Repository.php 
verwendet

somit denke ich dass typen änderung nicht kritisch ist